### PR TITLE
Bump version numbers of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-hash32 = "0.3"
+hash32 = "0.2"
 hash32-derive = "0.1"
 heapless = "0.7"
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,19 @@ categories = ["gui"]
 license = "MIT"
 
 [dependencies]
-arrayvec = { version = "0.7.2", default-features = false }
-hash32 = "0.2.1"
-hash32-derive = "0.1.1"
-heapless = "0.7.9"
-num-traits = { version = "0.2.14", default-features = false }
-typenum = "1.15.0"
+arrayvec = { version = "0.7", default-features = false }
+hash32 = "0.3"
+hash32-derive = "0.1"
+heapless = "0.7"
+num-traits = { version = "0.2", default-features = false }
+typenum = "1"
 
 [dependencies.hashbrown]
-version = "0.12.0"
+version = "0.12"
 optional = true
 
 [dependencies.serde]
-version = "1.0.132"
+version = "1.0"
 features = ["serde_derive"]
 optional = true
 
@@ -35,7 +35,7 @@ serde_camel_case = ["serde"]
 serde_kebab_case = ["serde"]
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.3"
 
 [profile.release]
 lto = true

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - renamed crate from `stretch2` to `sprawl`
+- updated to the latest version of all dependencies to reduce upstream pain caused by duplicate dependencies
 
 ### Removed
 


### PR DESCRIPTION
# Objective

- some dependencies (like serde) were out of date
  - this can have correctness or performance implications
  - more importantly, this can cause frustrating dependency duplication in upstream consumers, bloating compile times and executable size
- our version numbers were specified overly precisely, pinning minor versions
  - this forces us to update dependencies manually too frequently, whenever bug fixes are released
  - consumers who want to prioritize supply chain security can use [cargo patch](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) to pin the transitive dependencies themselves.
