### PR TITLE
Remove hash32 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ license = "MIT"
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
-hash32 = "0.2.1"
-hash32-derive = "0.1.1"
 heapless = "0.7.9"
 num-traits = { version = "0.2.14", default-features = false }
 typenum = "1.15.0"

--- a/src/id.rs
+++ b/src/id.rs
@@ -7,7 +7,6 @@ use core::sync::atomic;
 pub(crate) type NodeId = usize;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]
 pub(crate) struct Id(usize);
 
 pub(crate) struct Allocator {

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,7 +19,6 @@ pub enum MeasureFunc {
 static INSTANCE_ALLOCATOR: id::Allocator = id::Allocator::new();
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]
 pub struct Node {
     instance: id::Id,
     local: id::Id,

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -68,7 +68,7 @@ mod core {
 
     pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where
-        K: Eq + ::hash32::Hash,
+        K: Eq + core::hash::Hash,
     {
         Map::new()
     }


### PR DESCRIPTION
# Objective

The use of `hash32` is poorly justified: in theory it should speed up Hash operations on 32 bit platforms. However, we a) have no users that require this at the moment and b) have no benchmarks to back it up.

This PR removes its use entirely. It can be re-added later if its use is properly motivated.

## Context

- See the [hash32 docs](https://docs.rs/hash32/latest/hash32/) for background.
- This will not break `no_std` support, as the `hash` trait lives in `core`, not `std`.
- The upgrade for this crate was failing in #61. 
