### PR TITLE
Rename `sprawl::node::Stretch` -> `sprawl::node::Sprawl`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,7 @@
 
 - renamed crate from `stretch2` to `sprawl`
 - updated to the latest version of all dependencies to reduce upstream pain caused by duplicate dependencies
+- Renamed `sprawl::node::Strech` -> `sprawl::node::Sprawl`
 
 ### Removed
 

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn build_deep_hierarchy(stretch: &mut sprawl::node::Sprawl) -> sprawl::node::Node {
-    let node111 = stretch
+fn build_deep_hierarchy(sprawl: &mut sprawl::node::Sprawl) -> sprawl::node::Node {
+    let node111 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size {
@@ -13,32 +13,7 @@ fn build_deep_hierarchy(stretch: &mut sprawl::node::Sprawl) -> sprawl::node::Nod
             &[],
         )
         .unwrap();
-    let node112 = stretch
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-
-    let node121 = stretch
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node122 = stretch
+    let node112 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size {
@@ -51,11 +26,7 @@ fn build_deep_hierarchy(stretch: &mut sprawl::node::Sprawl) -> sprawl::node::Nod
         )
         .unwrap();
 
-    let node11 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node111, node112]).unwrap();
-    let node12 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node121, node122]).unwrap();
-    let node1 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node11, node12]).unwrap();
-
-    let node211 = stretch
+    let node121 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size {
@@ -67,32 +38,7 @@ fn build_deep_hierarchy(stretch: &mut sprawl::node::Sprawl) -> sprawl::node::Nod
             &[],
         )
         .unwrap();
-    let node212 = stretch
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-
-    let node221 = stretch
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node222 = stretch
+    let node122 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size {
@@ -105,40 +51,94 @@ fn build_deep_hierarchy(stretch: &mut sprawl::node::Sprawl) -> sprawl::node::Nod
         )
         .unwrap();
 
-    let node21 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node211, node212]).unwrap();
-    let node22 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node221, node222]).unwrap();
+    let node11 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node111, node112]).unwrap();
+    let node12 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node121, node122]).unwrap();
+    let node1 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node11, node12]).unwrap();
 
-    let node2 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node21, node22]).unwrap();
+    let node211 = sprawl
+        .new_node(
+            sprawl::style::Style {
+                size: sprawl::geometry::Size {
+                    width: sprawl::style::Dimension::Points(10.0),
+                    height: sprawl::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node212 = sprawl
+        .new_node(
+            sprawl::style::Style {
+                size: sprawl::geometry::Size {
+                    width: sprawl::style::Dimension::Points(10.0),
+                    height: sprawl::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
 
-    stretch.new_node(sprawl::style::Style { ..Default::default() }, &[node1, node2]).unwrap()
+    let node221 = sprawl
+        .new_node(
+            sprawl::style::Style {
+                size: sprawl::geometry::Size {
+                    width: sprawl::style::Dimension::Points(10.0),
+                    height: sprawl::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node222 = sprawl
+        .new_node(
+            sprawl::style::Style {
+                size: sprawl::geometry::Size {
+                    width: sprawl::style::Dimension::Points(10.0),
+                    height: sprawl::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+
+    let node21 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node211, node212]).unwrap();
+    let node22 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node221, node222]).unwrap();
+
+    let node2 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node21, node22]).unwrap();
+
+    sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node1, node2]).unwrap()
 }
 
-fn stretch_benchmarks(c: &mut Criterion) {
+fn sprawl_benchmarks(c: &mut Criterion) {
     c.bench_function("deep hierarchy - build", |b| {
         b.iter(|| {
-            let mut stretch = sprawl::node::Sprawl::new();
-            build_deep_hierarchy(&mut stretch);
+            let mut sprawl = sprawl::node::Sprawl::new();
+            build_deep_hierarchy(&mut sprawl);
         })
     });
 
     c.bench_function("deep hierarchy - single", |b| {
         b.iter(|| {
-            let mut stretch = sprawl::node::Sprawl::new();
-            let root = build_deep_hierarchy(&mut stretch);
-            stretch.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
+            let mut sprawl = sprawl::node::Sprawl::new();
+            let root = build_deep_hierarchy(&mut sprawl);
+            sprawl.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
         })
     });
 
     c.bench_function("deep hierarchy - relayout", |b| {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let root = build_deep_hierarchy(&mut stretch);
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let root = build_deep_hierarchy(&mut sprawl);
 
         b.iter(|| {
-            stretch.mark_dirty(root).unwrap();
-            stretch.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
+            sprawl.mark_dirty(root).unwrap();
+            sprawl.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
         })
     });
 }
 
-criterion_group!(benches, stretch_benchmarks);
+criterion_group!(benches, sprawl_benchmarks);
 criterion_main!(benches);

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn build_deep_hierarchy(stretch: &mut sprawl::node::Stretch) -> sprawl::node::Node {
+fn build_deep_hierarchy(stretch: &mut sprawl::node::Sprawl) -> sprawl::node::Node {
     let node111 = stretch
         .new_node(
             sprawl::style::Style {
@@ -116,21 +116,21 @@ fn build_deep_hierarchy(stretch: &mut sprawl::node::Stretch) -> sprawl::node::No
 fn stretch_benchmarks(c: &mut Criterion) {
     c.bench_function("deep hierarchy - build", |b| {
         b.iter(|| {
-            let mut stretch = sprawl::node::Stretch::new();
+            let mut stretch = sprawl::node::Sprawl::new();
             build_deep_hierarchy(&mut stretch);
         })
     });
 
     c.bench_function("deep hierarchy - single", |b| {
         b.iter(|| {
-            let mut stretch = sprawl::node::Stretch::new();
+            let mut stretch = sprawl::node::Sprawl::new();
             let root = build_deep_hierarchy(&mut stretch);
             stretch.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
         })
     });
 
     c.bench_function("deep hierarchy - relayout", |b| {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let root = build_deep_hierarchy(&mut stretch);
 
         b.iter(|| {

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_center.rs
+++ b/benches/generated/absolute_layout_align_items_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/benches/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_child_order.rs
+++ b/benches/generated/absolute_layout_child_order.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_justify_content_center.rs
+++ b/benches/generated/absolute_layout_justify_content_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_no_size.rs
+++ b/benches/generated/absolute_layout_no_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },

--- a/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_start_top_end_bottom.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_width_height_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_end_bottom.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_width_height_start_top.rs
+++ b/benches/generated/absolute_layout_width_height_start_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/absolute_layout_within_border.rs
+++ b/benches/generated/absolute_layout_within_border.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_baseline.rs
+++ b/benches/generated/align_baseline.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_baseline_child_multiline.rs
+++ b/benches/generated/align_baseline_child_multiline.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_baseline_nested_child.rs
+++ b/benches/generated/align_baseline_nested_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_center_should_size_based_on_content.rs
+++ b/benches/generated/align_center_should_size_based_on_content.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_flex_start_with_shrinking_children.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/benches/generated/align_flex_start_with_stretching_children.rs
+++ b/benches/generated/align_flex_start_with_stretching_children.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/benches/generated/align_items_center.rs
+++ b/benches/generated/align_items_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_center_with_child_margin.rs
+++ b/benches/generated/align_items_center_with_child_margin.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_center_with_child_top.rs
+++ b/benches/generated/align_items_center_with_child_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_flex_end.rs
+++ b/benches/generated/align_items_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_flex_start.rs
+++ b/benches/generated/align_items_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_min_max.rs
+++ b/benches/generated/align_items_min_max.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_items_stretch.rs
+++ b/benches/generated/align_items_stretch.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_self_baseline.rs
+++ b/benches/generated/align_self_baseline.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_self_center.rs
+++ b/benches/generated/align_self_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_self_flex_end.rs
+++ b/benches/generated/align_self_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_self_flex_end_override_flex_start.rs
+++ b/benches/generated/align_self_flex_end_override_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_self_flex_start.rs
+++ b/benches/generated/align_self_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/align_strech_should_size_based_on_parent.rs
+++ b/benches/generated/align_strech_should_size_based_on_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/border_center_child.rs
+++ b/benches/generated/border_center_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/border_flex_child.rs
+++ b/benches/generated/border_flex_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/border_no_child.rs
+++ b/benches/generated/border_no_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/border_stretch_child.rs
+++ b/benches/generated/border_stretch_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/child_min_max_width_flexing.rs
+++ b/benches/generated/child_min_max_width_flexing.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/container_with_unsized_child.rs
+++ b/benches/generated/container_with_unsized_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(

--- a/benches/generated/display_none.rs
+++ b/benches/generated/display_none.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/benches/generated/display_none_fixed_size.rs
+++ b/benches/generated/display_none_fixed_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/benches/generated/display_none_with_child.rs
+++ b/benches/generated/display_none_with_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/display_none_with_margin.rs
+++ b/benches/generated/display_none_with_margin.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/display_none_with_position.rs
+++ b/benches/generated/display_none_with_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_flex_grow_column.rs
+++ b/benches/generated/flex_basis_flex_grow_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_flex_grow_row.rs
+++ b/benches/generated/flex_basis_flex_grow_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_flex_shrink_column.rs
+++ b/benches/generated/flex_basis_flex_shrink_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },

--- a/benches/generated/flex_basis_flex_shrink_row.rs
+++ b/benches/generated/flex_basis_flex_shrink_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },

--- a/benches/generated/flex_basis_larger_than_content_column.rs
+++ b/benches/generated/flex_basis_larger_than_content_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_larger_than_content_row.rs
+++ b/benches/generated/flex_basis_larger_than_content_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_overrides_main_size.rs
+++ b/benches/generated/flex_basis_overrides_main_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_than_content_column.rs
+++ b/benches/generated/flex_basis_smaller_than_content_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_than_content_row.rs
+++ b/benches/generated/flex_basis_smaller_than_content_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_unconstraint_column.rs
+++ b/benches/generated/flex_basis_unconstraint_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_basis_unconstraint_row.rs
+++ b/benches/generated/flex_basis_unconstraint_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_direction_column.rs
+++ b/benches/generated/flex_direction_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_direction_column_no_height.rs
+++ b/benches/generated/flex_direction_column_no_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_direction_column_reverse.rs
+++ b/benches/generated/flex_direction_column_reverse.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_direction_row.rs
+++ b/benches/generated/flex_direction_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_direction_row_no_width.rs
+++ b/benches/generated/flex_direction_row_no_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_direction_row_reverse.rs
+++ b/benches/generated/flex_direction_row_reverse.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_child.rs
+++ b/benches/generated/flex_grow_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/benches/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_height_maximized.rs
+++ b/benches/generated/flex_grow_height_maximized.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_in_at_most_container.rs
+++ b/benches/generated/flex_grow_in_at_most_container.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_less_than_factor_one.rs
+++ b/benches/generated/flex_grow_less_than_factor_one.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_root_minimized.rs
+++ b/benches/generated/flex_grow_root_minimized.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_shrink_at_most.rs
+++ b/benches/generated/flex_grow_shrink_at_most.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/benches/generated/flex_grow_to_min.rs
+++ b/benches/generated/flex_grow_to_min.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/benches/generated/flex_grow_within_constrained_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_max_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_within_constrained_max_row.rs
+++ b/benches/generated/flex_grow_within_constrained_max_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_within_constrained_max_width.rs
+++ b/benches/generated/flex_grow_within_constrained_max_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_grow_within_constrained_min_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/benches/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_max_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/benches/generated/flex_grow_within_constrained_min_row.rs
+++ b/benches/generated/flex_grow_within_constrained_min_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/benches/generated/flex_grow_within_max_width.rs
+++ b/benches/generated/flex_grow_within_max_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_root_ignored.rs
+++ b/benches/generated/flex_root_ignored.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_shrink_flex_grow_row.rs
+++ b/benches/generated/flex_shrink_flex_grow_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_shrink_to_zero.rs
+++ b/benches/generated/flex_shrink_to_zero.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/flex_wrap_wrap_to_child_height.rs
+++ b/benches/generated/flex_wrap_wrap_to_child_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_center.rs
+++ b/benches/generated/justify_content_column_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_flex_end.rs
+++ b/benches/generated/justify_content_column_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_flex_start.rs
+++ b/benches/generated/justify_content_column_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_space_around.rs
+++ b/benches/generated/justify_content_column_space_around.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_space_between.rs
+++ b/benches/generated/justify_content_column_space_between.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_column_space_evenly.rs
+++ b/benches/generated/justify_content_column_space_evenly.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_min_max.rs
+++ b/benches/generated/justify_content_min_max.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_overflow_min_max.rs
+++ b/benches/generated/justify_content_overflow_min_max.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_center.rs
+++ b/benches/generated/justify_content_row_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_flex_end.rs
+++ b/benches/generated/justify_content_row_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_flex_start.rs
+++ b/benches/generated/justify_content_row_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_max_width_and_margin.rs
+++ b/benches/generated/justify_content_row_max_width_and_margin.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_min_width_and_margin.rs
+++ b/benches/generated/justify_content_row_min_width_and_margin.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_space_around.rs
+++ b/benches/generated/justify_content_row_space_around.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_space_between.rs
+++ b/benches/generated/justify_content_row_space_between.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/justify_content_row_space_evenly.rs
+++ b/benches/generated/justify_content_row_space_evenly.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_and_flex_column.rs
+++ b/benches/generated/margin_and_flex_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_and_flex_row.rs
+++ b/benches/generated/margin_and_flex_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_and_stretch_column.rs
+++ b/benches/generated/margin_and_stretch_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_and_stretch_row.rs
+++ b/benches/generated/margin_and_stretch_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_bottom.rs
+++ b/benches/generated/margin_auto_bottom.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_bottom_and_top.rs
+++ b/benches/generated/margin_auto_bottom_and_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/benches/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left.rs
+++ b/benches/generated/margin_auto_left.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_and_right.rs
+++ b/benches/generated/margin_auto_left_and_right.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_and_right_column.rs
+++ b/benches/generated/margin_auto_left_and_right_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/benches/generated/margin_auto_left_and_right_column_and_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_and_right_strech.rs
+++ b/benches/generated/margin_auto_left_and_right_strech.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_left_stretching_child.rs
+++ b/benches/generated/margin_auto_left_stretching_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_mutiple_children_column.rs
+++ b/benches/generated/margin_auto_mutiple_children_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_mutiple_children_row.rs
+++ b/benches/generated/margin_auto_mutiple_children_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_right.rs
+++ b/benches/generated/margin_auto_right.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_top.rs
+++ b/benches/generated/margin_auto_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_top_and_bottom_strech.rs
+++ b/benches/generated/margin_auto_top_and_bottom_strech.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_auto_top_stretching_child.rs
+++ b/benches/generated/margin_auto_top_stretching_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_left.rs
+++ b/benches/generated/margin_left.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_should_not_be_part_of_max_height.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_should_not_be_part_of_max_width.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_top.rs
+++ b/benches/generated/margin_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_with_sibling_column.rs
+++ b/benches/generated/margin_with_sibling_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/margin_with_sibling_row.rs
+++ b/benches/generated/margin_with_sibling_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/max_height.rs
+++ b/benches/generated/max_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/max_height_overrides_height.rs
+++ b/benches/generated/max_height_overrides_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/max_height_overrides_height_on_root.rs
+++ b/benches/generated/max_height_overrides_height_on_root.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/max_width.rs
+++ b/benches/generated/max_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/max_width_overrides_width.rs
+++ b/benches/generated/max_width_overrides_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/max_width_overrides_width_on_root.rs
+++ b/benches/generated/max_width_overrides_width_on_root.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_height.rs
+++ b/benches/generated/min_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_height_overrides_height.rs
+++ b/benches/generated/min_height_overrides_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_height_overrides_height_on_root.rs
+++ b/benches/generated/min_height_overrides_height_on_root.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_max_percent_no_width_height.rs
+++ b/benches/generated/min_max_percent_no_width_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_width.rs
+++ b/benches/generated/min_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_width_overrides_width.rs
+++ b/benches/generated/min_width_overrides_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/min_width_overrides_width_on_root.rs
+++ b/benches/generated/min_width_overrides_width_on_root.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/nested_overflowing_child.rs
+++ b/benches/generated/nested_overflowing_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/benches/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/overflow_cross_axis.rs
+++ b/benches/generated/overflow_cross_axis.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/overflow_main_axis.rs
+++ b/benches/generated/overflow_main_axis.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/padding_center_child.rs
+++ b/benches/generated/padding_center_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/padding_flex_child.rs
+++ b/benches/generated/padding_flex_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/padding_no_child.rs
+++ b/benches/generated/padding_no_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/padding_stretch_child.rs
+++ b/benches/generated/padding_stretch_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/benches/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percent_absolute_position.rs
+++ b/benches/generated/percent_absolute_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percent_within_flex_grow.rs
+++ b/benches/generated/percent_within_flex_grow.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_absolute_position.rs
+++ b/benches/generated/percentage_absolute_position.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_container_in_wrapping_container.rs
+++ b/benches/generated/percentage_container_in_wrapping_container.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis.rs
+++ b/benches/generated/percentage_flex_basis.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_cross.rs
+++ b/benches/generated/percentage_flex_basis_cross.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_cross_max_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_cross_max_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_cross_min_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_cross_min_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_main_max_height.rs
+++ b/benches/generated/percentage_flex_basis_main_max_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_main_max_width.rs
+++ b/benches/generated/percentage_flex_basis_main_max_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_flex_basis_main_min_width.rs
+++ b/benches/generated/percentage_flex_basis_main_min_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_position_bottom_right.rs
+++ b/benches/generated/percentage_position_bottom_right.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_position_left_top.rs
+++ b/benches/generated/percentage_position_left_top.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/benches/generated/percentage_size_based_on_parent_inner_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_size_of_flex_basis.rs
+++ b/benches/generated/percentage_size_of_flex_basis.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_width_height.rs
+++ b/benches/generated/percentage_width_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/percentage_width_height_undefined_parent_size.rs
+++ b/benches/generated/percentage_width_height_undefined_parent_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/relative_position_should_not_nudge_siblings.rs
+++ b/benches/generated/relative_position_should_not_nudge_siblings.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node2 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();

--- a/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node2 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();

--- a/benches/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/benches/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/benches/generated/rounding_flex_basis_overrides_main_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_fractial_input_1.rs
+++ b/benches/generated/rounding_fractial_input_1.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_fractial_input_2.rs
+++ b/benches/generated/rounding_fractial_input_2.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_fractial_input_3.rs
+++ b/benches/generated/rounding_fractial_input_3.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_fractial_input_4.rs
+++ b/benches/generated/rounding_fractial_input_4.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_total_fractial.rs
+++ b/benches/generated/rounding_total_fractial.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/rounding_total_fractial_nested.rs
+++ b/benches/generated/rounding_total_fractial_nested.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/size_defined_by_child.rs
+++ b/benches/generated/size_defined_by_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/size_defined_by_child_with_border.rs
+++ b/benches/generated/size_defined_by_child_with_border.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/size_defined_by_child_with_padding.rs
+++ b/benches/generated/size_defined_by_child_with_padding.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/size_defined_by_grand_child.rs
+++ b/benches/generated/size_defined_by_grand_child.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_column.rs
+++ b/benches/generated/wrap_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_column.rs
+++ b/benches/generated/wrap_reverse_column.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_column_fixed_size.rs
+++ b/benches/generated/wrap_reverse_column_fixed_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_row.rs
+++ b/benches/generated/wrap_reverse_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_row_align_content_center.rs
+++ b/benches/generated/wrap_reverse_row_align_content_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/benches/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/benches/generated/wrap_reverse_row_align_content_space_around.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/benches/generated/wrap_reverse_row_align_content_stretch.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/benches/generated/wrap_reverse_row_single_line_different_size.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_row.rs
+++ b/benches/generated/wrap_row.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_row_align_items_center.rs
+++ b/benches/generated/wrap_row_align_items_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrap_row_align_items_flex_end.rs
+++ b/benches/generated/wrap_row_align_items_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrapped_column_max_height.rs
+++ b/benches/generated/wrapped_column_max_height.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrapped_column_max_height_flex.rs
+++ b/benches/generated/wrapped_column_max_height_flex.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrapped_row_within_align_items_center.rs
+++ b/benches/generated/wrapped_row_within_align_items_center.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_end.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/benches/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_start.rs
@@ -1,5 +1,5 @@
 pub fn compute() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use sprawl::prelude::*;
 
 fn main() -> Result<(), Error> {
-    let mut stretch = Stretch::new();
+    let mut stretch = Sprawl::new();
 
     let child = stretch.new_node(
         Style { size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto }, ..Default::default() },

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,14 +1,14 @@
 use sprawl::prelude::*;
 
 fn main() -> Result<(), Error> {
-    let mut stretch = Sprawl::new();
+    let mut sprawl = Sprawl::new();
 
-    let child = stretch.new_node(
+    let child = sprawl.new_node(
         Style { size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto }, ..Default::default() },
         &[],
     )?;
 
-    let node = stretch.new_node(
+    let node = sprawl.new_node(
         Style {
             size: Size { width: Dimension::Points(100.0), height: Dimension::Points(100.0) },
             justify_content: JustifyContent::Center,
@@ -17,13 +17,13 @@ fn main() -> Result<(), Error> {
         &[child],
     )?;
 
-    stretch.compute_layout(node, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
+    sprawl.compute_layout(node, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
 
     // or just use undefined for 100 x 100
-    // stretch.compute_layout(node, Size::undefined())?;
+    // sprawl.compute_layout(node, Size::undefined())?;
 
-    println!("node: {:#?}", stretch.layout(node)?);
-    println!("child: {:#?}", stretch.layout(child)?);
+    println!("node: {:#?}", sprawl.layout(node)?);
+    println!("child: {:#?}", sprawl.layout(child)?);
 
     Ok(())
 }

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,15 +1,15 @@
 use sprawl::prelude::*;
 
 fn main() -> Result<(), Error> {
-    let mut stretch = Sprawl::new();
+    let mut sprawl = Sprawl::new();
 
     // left
-    let child_t1 = stretch.new_node(
+    let child_t1 = sprawl.new_node(
         Style { size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, ..Default::default() },
         &[],
     )?;
 
-    let div1 = stretch.new_node(
+    let div1 = sprawl.new_node(
         Style {
             size: Size { width: Dimension::Percent(0.5), height: Dimension::Percent(1.0) },
             // justify_content: JustifyContent::Center,
@@ -19,12 +19,12 @@ fn main() -> Result<(), Error> {
     )?;
 
     // right
-    let child_t2 = stretch.new_node(
+    let child_t2 = sprawl.new_node(
         Style { size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, ..Default::default() },
         &[],
     )?;
 
-    let div2 = stretch.new_node(
+    let div2 = sprawl.new_node(
         Style {
             size: Size { width: Dimension::Percent(0.5), height: Dimension::Percent(1.0) },
             // justify_content: JustifyContent::Center,
@@ -33,20 +33,20 @@ fn main() -> Result<(), Error> {
         &[child_t2],
     )?;
 
-    let container = stretch.new_node(
+    let container = sprawl.new_node(
         Style { size: Size { width: Dimension::Percent(1.0), height: Dimension::Percent(1.0) }, ..Default::default() },
         &[div1, div2],
     )?;
 
-    stretch.compute_layout(container, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
+    sprawl.compute_layout(container, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
 
-    println!("node: {:#?}", stretch.layout(container)?);
+    println!("node: {:#?}", sprawl.layout(container)?);
 
-    println!("div1: {:#?}", stretch.layout(div1)?);
-    println!("div2: {:#?}", stretch.layout(div2)?);
+    println!("div1: {:#?}", sprawl.layout(div1)?);
+    println!("div2: {:#?}", sprawl.layout(div2)?);
 
-    println!("child1: {:#?}", stretch.layout(child_t1)?);
-    println!("child2: {:#?}", stretch.layout(child_t2)?);
+    println!("child1: {:#?}", sprawl.layout(child_t1)?);
+    println!("child2: {:#?}", sprawl.layout(child_t2)?);
 
     Ok(())
 }

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,7 +1,7 @@
 use sprawl::prelude::*;
 
 fn main() -> Result<(), Error> {
-    let mut stretch = Stretch::new();
+    let mut stretch = Sprawl::new();
 
     // left
     let child_t1 = stretch.new_node(

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -1,6 +1,6 @@
 //! Forest - ECS like datastructure for storing node trees.
 //!
-//! Backing datastructure for `Stretch` structs.
+//! Backing datastructure for `Sprawl` structs.
 use crate::geometry::Size;
 use crate::id::NodeId;
 use crate::node::MeasureFunc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod sys;
 #[cfg(feature = "std")]
 use core::fmt::{Display, Formatter, Result};
 
-pub use crate::node::Stretch;
+pub use crate::node::Sprawl;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::InvalidNode(_) => "The node is not part of the stretch instance",
+            Error::InvalidNode(_) => "The node is not part of the sprawl instance",
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,7 +17,7 @@ pub enum MeasureFunc {
     Boxed(Box<dyn Fn(Size<Number>) -> Size<f32>>),
 }
 
-/// Global stretch instance id allocator.
+/// Global sprawl instance id allocator.
 static INSTANCE_ALLOCATOR: Allocator = Allocator::new();
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -27,7 +27,7 @@ pub struct Node {
     local: Id,
 }
 
-pub struct Stretch {
+pub struct Sprawl {
     id: Id,
     nodes: Allocator,
     nodes_to_ids: Map<Node, NodeId>,
@@ -35,13 +35,13 @@ pub struct Stretch {
     forest: Forest,
 }
 
-impl Default for Stretch {
+impl Default for Sprawl {
     fn default() -> Self {
         Self::with_capacity(16)
     }
 }
 
-impl Stretch {
+impl Sprawl {
     pub fn new() -> Self {
         Default::default()
     }
@@ -231,7 +231,7 @@ impl Stretch {
     }
 }
 
-impl Drop for Stretch {
+impl Drop for Sprawl {
     fn drop(&mut self) {
         INSTANCE_ALLOCATOR.free(&[self.id]);
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use crate::{
     geometry::{Rect, Size},
-    node::{Node, Stretch},
+    node::{Node, Sprawl},
     number::Number,
     result::Layout,
     style::{

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_center.rs
+++ b/tests/generated/absolute_layout_align_items_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/tests/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_align_items_center_on_child_only() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_child_order() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_column_container() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_row_container() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_justify_content_center.rs
+++ b/tests/generated/absolute_layout_justify_content_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_justify_content_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_no_size.rs
+++ b/tests/generated/absolute_layout_no_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_no_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },

--- a/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_percentage_bottom_based_on_parent_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_start_top_end_bottom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_start_top_end_bottom() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_width_height_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_end_bottom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_width_height_end_bottom() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_width_height_start_top.rs
+++ b/tests/generated/absolute_layout_width_height_start_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_width_height_start_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_width_height_start_top_end_bottom() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/absolute_layout_within_border.rs
+++ b/tests/generated/absolute_layout_within_border.rs
@@ -1,6 +1,6 @@
 #[test]
 fn absolute_layout_within_border() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_baseline.rs
+++ b/tests/generated/align_baseline.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_baseline() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_baseline_child_multiline.rs
+++ b/tests/generated/align_baseline_child_multiline.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_baseline_child_multiline() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_baseline_nested_child.rs
+++ b/tests/generated/align_baseline_nested_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_baseline_nested_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_center_should_size_based_on_content.rs
+++ b/tests/generated/align_center_should_size_based_on_content.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_center_should_size_based_on_content() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_flex_start_with_shrinking_children.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_flex_start_with_shrinking_children() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_flex_start_with_shrinking_children_with_stretch() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/tests/generated/align_flex_start_with_stretching_children.rs
+++ b/tests/generated/align_flex_start_with_stretching_children.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_flex_start_with_stretching_children() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/tests/generated/align_items_center.rs
+++ b/tests/generated/align_items_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_center_child_with_margin_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_center_child_without_margin_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_center_with_child_margin.rs
+++ b/tests/generated/align_items_center_with_child_margin.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_center_with_child_margin() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_center_with_child_top.rs
+++ b/tests/generated/align_items_center_with_child_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_center_with_child_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_flex_end.rs
+++ b/tests/generated/align_items_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_flex_end_child_with_margin_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_flex_end_child_without_margin_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_flex_start.rs
+++ b/tests/generated/align_items_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_min_max.rs
+++ b/tests/generated/align_items_min_max.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_min_max() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_items_stretch.rs
+++ b/tests/generated/align_items_stretch.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_items_stretch() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_self_baseline.rs
+++ b/tests/generated/align_self_baseline.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_self_baseline() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_self_center.rs
+++ b/tests/generated/align_self_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_self_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_self_flex_end.rs
+++ b/tests/generated/align_self_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_self_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_self_flex_end_override_flex_start.rs
+++ b/tests/generated/align_self_flex_end_override_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_self_flex_end_override_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_self_flex_start.rs
+++ b/tests/generated/align_self_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_self_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/align_strech_should_size_based_on_parent.rs
+++ b/tests/generated/align_strech_should_size_based_on_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn align_strech_should_size_based_on_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/border_center_child.rs
+++ b/tests/generated/border_center_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn border_center_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/border_flex_child.rs
+++ b/tests/generated/border_flex_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn border_flex_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/border_no_child.rs
+++ b/tests/generated/border_no_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn border_no_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/border_stretch_child.rs
+++ b/tests/generated/border_stretch_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn border_stretch_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/child_min_max_width_flexing.rs
+++ b/tests/generated/child_min_max_width_flexing.rs
@@ -1,6 +1,6 @@
 #[test]
 fn child_min_max_width_flexing() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/container_with_unsized_child.rs
+++ b/tests/generated/container_with_unsized_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn container_with_unsized_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
     let node = stretch
         .new_node(

--- a/tests/generated/display_none.rs
+++ b/tests/generated/display_none.rs
@@ -1,6 +1,6 @@
 #[test]
 fn display_none() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/tests/generated/display_none_fixed_size.rs
+++ b/tests/generated/display_none_fixed_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn display_none_fixed_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/tests/generated/display_none_with_child.rs
+++ b/tests/generated/display_none_with_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn display_none_with_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/display_none_with_margin.rs
+++ b/tests/generated/display_none_with_margin.rs
@@ -1,6 +1,6 @@
 #[test]
 fn display_none_with_margin() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/display_none_with_position.rs
+++ b/tests/generated/display_none_with_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn display_none_with_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_and_main_dimen_set_when_flexing() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_flex_grow_column.rs
+++ b/tests/generated/flex_basis_flex_grow_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_flex_grow_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_flex_grow_row.rs
+++ b/tests/generated/flex_basis_flex_grow_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_flex_grow_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_flex_shrink_column.rs
+++ b/tests/generated/flex_basis_flex_shrink_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_flex_shrink_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },

--- a/tests/generated/flex_basis_flex_shrink_row.rs
+++ b/tests/generated/flex_basis_flex_shrink_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_flex_shrink_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },

--- a/tests/generated/flex_basis_larger_than_content_column.rs
+++ b/tests/generated/flex_basis_larger_than_content_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_larger_than_content_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_larger_than_content_row.rs
+++ b/tests/generated/flex_basis_larger_than_content_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_larger_than_content_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_overrides_main_size.rs
+++ b/tests/generated/flex_basis_overrides_main_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_overrides_main_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_than_content_column.rs
+++ b/tests/generated/flex_basis_smaller_than_content_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_than_content_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_than_content_row.rs
+++ b/tests/generated/flex_basis_smaller_than_content_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_than_content_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_than_main_dimen_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_than_main_dimen_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_unconstraint_column.rs
+++ b/tests/generated/flex_basis_unconstraint_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_unconstraint_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_basis_unconstraint_row.rs
+++ b/tests/generated/flex_basis_unconstraint_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_basis_unconstraint_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_direction_column.rs
+++ b/tests/generated/flex_direction_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_direction_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_direction_column_no_height.rs
+++ b/tests/generated/flex_direction_column_no_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_direction_column_no_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_direction_column_reverse.rs
+++ b/tests/generated/flex_direction_column_reverse.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_direction_column_reverse() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_direction_row.rs
+++ b/tests/generated/flex_direction_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_direction_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_direction_row_no_width.rs
+++ b/tests/generated/flex_direction_row_no_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_direction_row_no_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_direction_row_reverse.rs
+++ b/tests/generated/flex_direction_row_reverse.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_direction_row_reverse() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_child.rs
+++ b/tests/generated/flex_grow_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/tests/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_flex_basis_percent_min_max() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_height_maximized.rs
+++ b/tests/generated/flex_grow_height_maximized.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_height_maximized() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_in_at_most_container.rs
+++ b/tests/generated/flex_grow_in_at_most_container.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_in_at_most_container() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_less_than_factor_one.rs
+++ b/tests/generated/flex_grow_less_than_factor_one.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_less_than_factor_one() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_root_minimized.rs
+++ b/tests/generated/flex_grow_root_minimized.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_root_minimized() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_shrink_at_most.rs
+++ b/tests/generated/flex_grow_shrink_at_most.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_shrink_at_most() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/tests/generated/flex_grow_to_min.rs
+++ b/tests/generated/flex_grow_to_min.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_to_min() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
         .unwrap();

--- a/tests/generated/flex_grow_within_constrained_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_max_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_constrained_max_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_within_constrained_max_row.rs
+++ b/tests/generated/flex_grow_within_constrained_max_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_constrained_max_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_within_constrained_max_width.rs
+++ b/tests/generated/flex_grow_within_constrained_max_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_constrained_max_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_grow_within_constrained_min_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_constrained_min_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/tests/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_max_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_constrained_min_max_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/tests/generated/flex_grow_within_constrained_min_row.rs
+++ b/tests/generated/flex_grow_within_constrained_min_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_constrained_min_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch
         .new_node(

--- a/tests/generated/flex_grow_within_max_width.rs
+++ b/tests/generated/flex_grow_within_max_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_grow_within_max_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_root_ignored.rs
+++ b/tests/generated/flex_root_ignored.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_root_ignored() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_shrink_by_outer_margin_with_max_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_shrink_flex_grow_row.rs
+++ b/tests/generated/flex_shrink_flex_grow_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_shrink_flex_grow_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_shrink_to_zero.rs
+++ b/tests/generated/flex_shrink_to_zero.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_shrink_to_zero() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_wrap_align_stretch_fits_one_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_wrap_children_with_min_main_overriding_flex_basis() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/flex_wrap_wrap_to_child_height.rs
+++ b/tests/generated/flex_wrap_wrap_to_child_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn flex_wrap_wrap_to_child_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_center.rs
+++ b/tests/generated/justify_content_column_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_flex_end.rs
+++ b/tests/generated/justify_content_column_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_flex_start.rs
+++ b/tests/generated/justify_content_column_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_min_height_and_margin_bottom() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_min_height_and_margin_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_space_around.rs
+++ b/tests/generated/justify_content_column_space_around.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_space_around() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_space_between.rs
+++ b/tests/generated/justify_content_column_space_between.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_space_between() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_column_space_evenly.rs
+++ b/tests/generated/justify_content_column_space_evenly.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_column_space_evenly() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_min_max.rs
+++ b/tests/generated/justify_content_min_max.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_min_max() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_overflow_min_max.rs
+++ b/tests/generated/justify_content_overflow_min_max.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_overflow_min_max() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_center.rs
+++ b/tests/generated/justify_content_row_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_flex_end.rs
+++ b/tests/generated/justify_content_row_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_flex_start.rs
+++ b/tests/generated/justify_content_row_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_max_width_and_margin.rs
+++ b/tests/generated/justify_content_row_max_width_and_margin.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_max_width_and_margin() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_min_width_and_margin.rs
+++ b/tests/generated/justify_content_row_min_width_and_margin.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_min_width_and_margin() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_space_around.rs
+++ b/tests/generated/justify_content_row_space_around.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_space_around() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_space_between.rs
+++ b/tests/generated/justify_content_row_space_between.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_space_between() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/justify_content_row_space_evenly.rs
+++ b/tests/generated/justify_content_row_space_evenly.rs
@@ -1,6 +1,6 @@
 #[test]
 fn justify_content_row_space_evenly() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_and_flex_column.rs
+++ b/tests/generated/margin_and_flex_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_and_flex_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_and_flex_row.rs
+++ b/tests/generated/margin_and_flex_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_and_flex_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_and_stretch_column.rs
+++ b/tests/generated/margin_and_stretch_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_and_stretch_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_and_stretch_row.rs
+++ b/tests/generated/margin_and_stretch_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_and_stretch_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_bottom.rs
+++ b/tests/generated/margin_auto_bottom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_bottom() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_bottom_and_top.rs
+++ b/tests/generated/margin_auto_bottom_and_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_bottom_and_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/tests/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_bottom_and_top_justify_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left.rs
+++ b/tests/generated/margin_auto_left.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_and_right.rs
+++ b/tests/generated/margin_auto_left_and_right.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_and_right() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_and_right_column.rs
+++ b/tests/generated/margin_auto_left_and_right_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_and_right_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/tests/generated/margin_auto_left_and_right_column_and_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_and_right_column_and_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_and_right_strech.rs
+++ b/tests/generated/margin_auto_left_and_right_strech.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_and_right_strech() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_child_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_fix_right_child_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_right_child_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_left_stretching_child.rs
+++ b/tests/generated/margin_auto_left_stretching_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_left_stretching_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_mutiple_children_column.rs
+++ b/tests/generated/margin_auto_mutiple_children_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_mutiple_children_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_mutiple_children_row.rs
+++ b/tests/generated/margin_auto_mutiple_children_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_mutiple_children_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_right.rs
+++ b/tests/generated/margin_auto_right.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_right() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_top.rs
+++ b/tests/generated/margin_auto_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_top_and_bottom_strech.rs
+++ b/tests/generated/margin_auto_top_and_bottom_strech.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_top_and_bottom_strech() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_auto_top_stretching_child.rs
+++ b/tests/generated/margin_auto_top_stretching_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_auto_top_stretching_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_bottom() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_fix_left_auto_right_child_bigger_than_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_left.rs
+++ b/tests/generated/margin_left.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_left() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_right() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_should_not_be_part_of_max_height.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_should_not_be_part_of_max_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_should_not_be_part_of_max_width.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_should_not_be_part_of_max_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_top.rs
+++ b/tests/generated/margin_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_with_sibling_column.rs
+++ b/tests/generated/margin_with_sibling_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_with_sibling_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/margin_with_sibling_row.rs
+++ b/tests/generated/margin_with_sibling_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn margin_with_sibling_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/max_height.rs
+++ b/tests/generated/max_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn max_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/max_height_overrides_height.rs
+++ b/tests/generated/max_height_overrides_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn max_height_overrides_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/max_height_overrides_height_on_root.rs
+++ b/tests/generated/max_height_overrides_height_on_root.rs
@@ -1,6 +1,6 @@
 #[test]
 fn max_height_overrides_height_on_root() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/max_width.rs
+++ b/tests/generated/max_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn max_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/max_width_overrides_width.rs
+++ b/tests/generated/max_width_overrides_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn max_width_overrides_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/max_width_overrides_width_on_root.rs
+++ b/tests/generated/max_width_overrides_width_on_root.rs
@@ -1,6 +1,6 @@
 #[test]
 fn max_width_overrides_width_on_root() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_height.rs
+++ b/tests/generated/min_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_height_overrides_height.rs
+++ b/tests/generated/min_height_overrides_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_height_overrides_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_height_overrides_height_on_root.rs
+++ b/tests/generated/min_height_overrides_height_on_root.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_height_overrides_height_on_root() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_max_percent_no_width_height.rs
+++ b/tests/generated/min_max_percent_no_width_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_max_percent_no_width_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_width_overrides_width.rs
+++ b/tests/generated/min_width_overrides_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_width_overrides_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/min_width_overrides_width_on_root.rs
+++ b/tests/generated/min_width_overrides_width_on_root.rs
@@ -1,6 +1,6 @@
 #[test]
 fn min_width_overrides_width_on_root() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/nested_overflowing_child.rs
+++ b/tests/generated/nested_overflowing_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn nested_overflowing_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/tests/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn nested_overflowing_child_in_constraint_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/overflow_cross_axis.rs
+++ b/tests/generated/overflow_cross_axis.rs
@@ -1,6 +1,6 @@
 #[test]
 fn overflow_cross_axis() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/overflow_main_axis.rs
+++ b/tests/generated/overflow_main_axis.rs
@@ -1,6 +1,6 @@
 #[test]
 fn overflow_main_axis() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn padding_align_end_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/padding_center_child.rs
+++ b/tests/generated/padding_center_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn padding_center_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/padding_flex_child.rs
+++ b/tests/generated/padding_flex_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn padding_flex_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/padding_no_child.rs
+++ b/tests/generated/padding_no_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn padding_no_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/padding_stretch_child.rs
+++ b/tests/generated/padding_stretch_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn padding_stretch_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/tests/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -1,6 +1,6 @@
 #[test]
 fn parent_wrap_child_size_overflowing_parent() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percent_absolute_position.rs
+++ b/tests/generated/percent_absolute_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percent_absolute_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percent_within_flex_grow.rs
+++ b/tests/generated/percent_within_flex_grow.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percent_within_flex_grow() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_absolute_position.rs
+++ b/tests/generated/percentage_absolute_position.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_absolute_position() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_container_in_wrapping_container.rs
+++ b/tests/generated/percentage_container_in_wrapping_container.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_container_in_wrapping_container() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis.rs
+++ b/tests/generated/percentage_flex_basis.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_cross.rs
+++ b/tests/generated/percentage_flex_basis_cross.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_cross() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_cross_max_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_cross_max_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_cross_max_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_cross_max_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_cross_min_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_cross_min_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_cross_min_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_cross_min_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_main_max_height.rs
+++ b/tests/generated/percentage_flex_basis_main_max_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_main_max_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_main_max_width.rs
+++ b/tests/generated/percentage_flex_basis_main_max_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_main_max_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_flex_basis_main_min_width.rs
+++ b/tests/generated/percentage_flex_basis_main_min_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_flex_basis_main_min_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_margin_should_calculate_based_only_on_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_padding_should_calculate_based_only_on_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_position_bottom_right.rs
+++ b/tests/generated/percentage_position_bottom_right.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_position_bottom_right() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_position_left_top.rs
+++ b/tests/generated/percentage_position_left_top.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_position_left_top() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/tests/generated/percentage_size_based_on_parent_inner_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_size_based_on_parent_inner_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_size_of_flex_basis.rs
+++ b/tests/generated/percentage_size_of_flex_basis.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_size_of_flex_basis() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_width_height.rs
+++ b/tests/generated/percentage_width_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_width_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/percentage_width_height_undefined_parent_size.rs
+++ b/tests/generated/percentage_width_height_undefined_parent_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn percentage_width_height_undefined_parent_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/relative_position_should_not_nudge_siblings.rs
+++ b/tests/generated/relative_position_should_not_nudge_siblings.rs
@@ -1,6 +1,6 @@
 #[test]
 fn relative_position_should_not_nudge_siblings() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_flex_basis_flex_grow_row_prime_number_width() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node2 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();

--- a/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_flex_basis_flex_grow_row_width_of_100() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node1 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
     let node2 = stretch.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();

--- a/tests/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/tests/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_flex_basis_flex_shrink_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/tests/generated/rounding_flex_basis_overrides_main_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_flex_basis_overrides_main_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_fractial_input_1.rs
+++ b/tests/generated/rounding_fractial_input_1.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_fractial_input_1() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_fractial_input_2.rs
+++ b/tests/generated/rounding_fractial_input_2.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_fractial_input_2() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_fractial_input_3.rs
+++ b/tests/generated/rounding_fractial_input_3.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_fractial_input_3() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_fractial_input_4.rs
+++ b/tests/generated/rounding_fractial_input_4.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_fractial_input_4() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_total_fractial.rs
+++ b/tests/generated/rounding_total_fractial.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_total_fractial() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/rounding_total_fractial_nested.rs
+++ b/tests/generated/rounding_total_fractial_nested.rs
@@ -1,6 +1,6 @@
 #[test]
 fn rounding_total_fractial_nested() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/size_defined_by_child.rs
+++ b/tests/generated/size_defined_by_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn size_defined_by_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/size_defined_by_child_with_border.rs
+++ b/tests/generated/size_defined_by_child_with_border.rs
@@ -1,6 +1,6 @@
 #[test]
 fn size_defined_by_child_with_border() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/size_defined_by_child_with_padding.rs
+++ b/tests/generated/size_defined_by_child_with_padding.rs
@@ -1,6 +1,6 @@
 #[test]
 fn size_defined_by_child_with_padding() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/size_defined_by_grand_child.rs
+++ b/tests/generated/size_defined_by_grand_child.rs
@@ -1,6 +1,6 @@
 #[test]
 fn size_defined_by_grand_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_large_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_small_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_very_large_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_column.rs
+++ b/tests/generated/wrap_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_nodes_with_content_sizing_margin_cross() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_nodes_with_content_sizing_overflowing_margin() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node000 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_column.rs
+++ b/tests/generated/wrap_reverse_column.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_column() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_column_fixed_size.rs
+++ b/tests/generated/wrap_reverse_column_fixed_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_column_fixed_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_row.rs
+++ b/tests/generated/wrap_reverse_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_row_align_content_center.rs
+++ b/tests/generated/wrap_reverse_row_align_content_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_row_align_content_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/tests/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_row_align_content_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/tests/generated/wrap_reverse_row_align_content_space_around.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_row_align_content_space_around() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/tests/generated/wrap_reverse_row_align_content_stretch.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_row_align_content_stretch() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/tests/generated/wrap_reverse_row_single_line_different_size.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_reverse_row_single_line_different_size() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_row.rs
+++ b/tests/generated/wrap_row.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_row() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_row_align_items_center.rs
+++ b/tests/generated/wrap_row_align_items_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_row_align_items_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrap_row_align_items_flex_end.rs
+++ b/tests/generated/wrap_row_align_items_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrap_row_align_items_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrapped_column_max_height.rs
+++ b/tests/generated/wrapped_column_max_height.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrapped_column_max_height() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrapped_column_max_height_flex.rs
+++ b/tests/generated/wrapped_column_max_height_flex.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrapped_column_max_height_flex() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrapped_row_within_align_items_center.rs
+++ b/tests/generated/wrapped_row_within_align_items_center.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrapped_row_within_align_items_center() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_end.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrapped_row_within_align_items_flex_end() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_start.rs
@@ -1,6 +1,6 @@
 #[test]
 fn wrapped_row_within_align_items_flex_start() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node00 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -5,7 +5,7 @@ mod measure {
 
     #[test]
     fn measure_root() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let node = stretch
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
@@ -24,7 +24,7 @@ mod measure {
 
     #[test]
     fn measure_child() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
 
         let child = stretch
             .new_leaf(
@@ -48,7 +48,7 @@ mod measure {
 
     #[test]
     fn measure_child_constraint() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
@@ -83,7 +83,7 @@ mod measure {
 
     #[test]
     fn measure_child_constraint_padding_parent() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
@@ -123,7 +123,7 @@ mod measure {
 
     #[test]
     fn measure_child_with_flex_grow() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child0 = stretch
             .new_node(
                 sprawl::style::Style {
@@ -168,7 +168,7 @@ mod measure {
 
     #[test]
     fn measure_child_with_flex_shrink() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child0 = stretch
             .new_node(
                 sprawl::style::Style {
@@ -214,7 +214,7 @@ mod measure {
 
     #[test]
     fn remeasure_child_after_growing() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child0 = stretch
             .new_node(
                 sprawl::style::Style {
@@ -261,7 +261,7 @@ mod measure {
 
     #[test]
     fn remeasure_child_after_shrinking() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
 
         let child0 = stretch
             .new_node(
@@ -310,7 +310,7 @@ mod measure {
 
     #[test]
     fn remeasure_child_after_stretching() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
 
         let child = stretch
             .new_leaf(
@@ -344,7 +344,7 @@ mod measure {
 
     #[test]
     fn width_overrides_measure() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style {
@@ -370,7 +370,7 @@ mod measure {
 
     #[test]
     fn height_overrides_measure() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style {
@@ -396,7 +396,7 @@ mod measure {
 
     #[test]
     fn flex_basis_overrides_measure() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child0 = stretch
             .new_node(
                 sprawl::style::Style {
@@ -445,7 +445,7 @@ mod measure {
 
     #[test]
     fn stretch_overrides_measure() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
@@ -477,7 +477,7 @@ mod measure {
 
     #[test]
     fn measure_absolute_child() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },
@@ -509,7 +509,7 @@ mod measure {
 
     #[test]
     fn ignore_invalid_measure() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let child = stretch
             .new_leaf(
                 sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
@@ -540,7 +540,7 @@ mod measure {
     fn only_measure_once() {
         use std::sync::atomic;
 
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
 
         let grandchild = stretch

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -5,8 +5,8 @@ mod measure {
 
     #[test]
     fn measure_root() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let node = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let node = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -16,17 +16,17 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(node).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(node).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child() {
-        let mut stretch = sprawl::node::Sprawl::new();
+        let mut sprawl = sprawl::node::Sprawl::new();
 
-        let child = stretch
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -36,20 +36,20 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(node).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(node).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.height, 100.0);
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child_constraint() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -59,7 +59,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -72,19 +72,19 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(node).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(node).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.height, 100.0);
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child_constraint_padding_parent() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -94,7 +94,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -112,19 +112,19 @@ mod measure {
                 &[child],
             )
             .unwrap();
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(node).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(node).unwrap().size.height, 120.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(node).unwrap().size.height, 120.0);
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 30.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 30.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child_with_flex_grow() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child0 = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child0 = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -137,7 +137,7 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = stretch
+        let child1 = sprawl
             .new_leaf(
                 sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -147,7 +147,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -160,16 +160,16 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child1).unwrap().size.height, 50.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn measure_child_with_flex_shrink() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child0 = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child0 = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -183,7 +183,7 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = stretch
+        let child1 = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -193,7 +193,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -206,16 +206,16 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child1).unwrap().size.height, 50.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn remeasure_child_after_growing() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child0 = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child0 = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -228,7 +228,7 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = stretch
+        let child1 = sprawl
             .new_leaf(
                 sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
@@ -239,7 +239,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -253,17 +253,17 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn remeasure_child_after_shrinking() {
-        let mut stretch = sprawl::node::Sprawl::new();
+        let mut sprawl = sprawl::node::Sprawl::new();
 
-        let child0 = stretch
+        let child0 = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -277,7 +277,7 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = stretch
+        let child1 = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
@@ -288,7 +288,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -302,17 +302,17 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn remeasure_child_after_stretching() {
-        let mut stretch = sprawl::node::Sprawl::new();
+        let mut sprawl = sprawl::node::Sprawl::new();
 
-        let child = stretch
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
@@ -323,7 +323,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -336,16 +336,16 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn width_overrides_measure() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -361,17 +361,17 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn height_overrides_measure() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -387,17 +387,17 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 50.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn flex_basis_overrides_measure() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child0 = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child0 = sprawl
             .new_node(
                 sprawl::style::Style {
                     flex_basis: sprawl::style::Dimension::Points(50.0),
@@ -408,7 +408,7 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = stretch
+        let child1 = sprawl
             .new_leaf(
                 sprawl::style::Style {
                     flex_basis: sprawl::style::Dimension::Points(50.0),
@@ -422,7 +422,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -435,18 +435,18 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child0).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(child0).unwrap().size.height, 100.0);
-        assert_eq!(stretch.layout(child1).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child0).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(child0).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(child1).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn stretch_overrides_measure() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -456,7 +456,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -469,16 +469,16 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_absolute_child() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },
                 MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
@@ -488,7 +488,7 @@ mod measure {
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -501,23 +501,23 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 50.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn ignore_invalid_measure() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let child = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let child = sprawl
             .new_leaf(
                 sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|_| sprawl::geometry::Size { width: 200.0, height: 200.0 }),
             )
             .unwrap();
 
-        let node = stretch
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -530,20 +530,20 @@ mod measure {
             )
             .unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(stretch.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn only_measure_once() {
         use std::sync::atomic;
 
-        let mut stretch = sprawl::node::Sprawl::new();
+        let mut sprawl = sprawl::node::Sprawl::new();
         static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
 
-        let grandchild = stretch
+        let grandchild = sprawl
             .new_leaf(
                 sprawl::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
@@ -556,10 +556,10 @@ mod measure {
             )
             .unwrap();
 
-        let child = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[grandchild]).unwrap();
+        let child = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[grandchild]).unwrap();
 
-        let node = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
         assert_eq!(NUM_MEASURES.load(atomic::Ordering::Relaxed), 2);
     }

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod node {
     use sprawl::geometry::*;
-    use sprawl::node::{MeasureFunc, Stretch};
+    use sprawl::node::{MeasureFunc, Sprawl};
     use sprawl::style::*;
 
     #[test]
     fn children() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
         let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         let child2 = stretch.new_node(Style::default(), &[]).unwrap();
         let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
@@ -18,7 +18,7 @@ mod node {
 
     #[test]
     fn set_measure() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
         let node =
             stretch.new_leaf(Style::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 })).unwrap();
         stretch.compute_layout(node, Size::undefined()).unwrap();
@@ -31,7 +31,7 @@ mod node {
 
     #[test]
     fn add_child() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
         let node = stretch.new_node(Style::default(), &[]).unwrap();
         assert_eq!(stretch.child_count(node).unwrap(), 0);
 
@@ -46,7 +46,7 @@ mod node {
 
     #[test]
     fn remove_child() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         let child2 = stretch.new_node(Style::default(), &[]).unwrap();
@@ -64,7 +64,7 @@ mod node {
 
     #[test]
     fn remove_child_at_index() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         let child2 = stretch.new_node(Style::default(), &[]).unwrap();
@@ -82,7 +82,7 @@ mod node {
 
     #[test]
     fn replace_child_at_index() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         let child2 = stretch.new_node(Style::default(), &[]).unwrap();
@@ -98,7 +98,7 @@ mod node {
 
     #[test]
     fn remove() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let style2 = Style { flex_direction: FlexDirection::Column, ..Style::default() };
 
@@ -121,7 +121,7 @@ mod node {
 
     #[test]
     fn set_children() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         let child2 = stretch.new_node(Style::default(), &[]).unwrap();
@@ -142,7 +142,7 @@ mod node {
 
     #[test]
     fn set_style() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let node = stretch.new_node(Style::default(), &[]).unwrap();
         assert_eq!(stretch.style(node).unwrap().display, Display::Flex);
@@ -153,7 +153,7 @@ mod node {
 
     #[test]
     fn mark_dirty() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let child1 = stretch.new_node(Style::default(), &[]).unwrap();
         let child2 = stretch.new_node(Style::default(), &[]).unwrap();
@@ -179,7 +179,7 @@ mod node {
 
     #[test]
     fn remove_last_node() {
-        let mut stretch = Stretch::new();
+        let mut stretch = Sprawl::new();
 
         let parent = stretch.new_node(Style::default(), &[]).unwrap();
         let child = stretch.new_node(Style::default(), &[]).unwrap();

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -6,186 +6,186 @@ mod node {
 
     #[test]
     fn children() {
-        let mut stretch = Sprawl::new();
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
-        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
+        let mut sprawl = Sprawl::new();
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
 
-        assert_eq!(stretch.child_count(node).unwrap(), 2);
-        assert_eq!(stretch.children(node).unwrap()[0], child1);
-        assert_eq!(stretch.children(node).unwrap()[1], child2);
+        assert_eq!(sprawl.child_count(node).unwrap(), 2);
+        assert_eq!(sprawl.children(node).unwrap()[0], child1);
+        assert_eq!(sprawl.children(node).unwrap()[1], child2);
     }
 
     #[test]
     fn set_measure() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
         let node =
-            stretch.new_leaf(Style::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 })).unwrap();
-        stretch.compute_layout(node, Size::undefined()).unwrap();
-        assert_eq!(stretch.layout(node).unwrap().size.width, 200.0);
+            sprawl.new_leaf(Style::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 })).unwrap();
+        sprawl.compute_layout(node, Size::undefined()).unwrap();
+        assert_eq!(sprawl.layout(node).unwrap().size.width, 200.0);
 
-        stretch.set_measure(node, Some(MeasureFunc::Raw(|_| Size { width: 100.0, height: 100.0 }))).unwrap();
-        stretch.compute_layout(node, Size::undefined()).unwrap();
-        assert_eq!(stretch.layout(node).unwrap().size.width, 100.0);
+        sprawl.set_measure(node, Some(MeasureFunc::Raw(|_| Size { width: 100.0, height: 100.0 }))).unwrap();
+        sprawl.compute_layout(node, Size::undefined()).unwrap();
+        assert_eq!(sprawl.layout(node).unwrap().size.width, 100.0);
     }
 
     #[test]
     fn add_child() {
-        let mut stretch = Sprawl::new();
-        let node = stretch.new_node(Style::default(), &[]).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 0);
+        let mut sprawl = Sprawl::new();
+        let node = sprawl.new_node(Style::default(), &[]).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 0);
 
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        stretch.add_child(node, child1).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 1);
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        sprawl.add_child(node, child1).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 1);
 
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
-        stretch.add_child(node, child2).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 2);
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        sprawl.add_child(node, child2).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 2);
     }
 
     #[test]
     fn remove_child() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
 
-        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 2);
+        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 2);
 
-        stretch.remove_child(node, child1).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 1);
-        assert_eq!(stretch.children(node).unwrap()[0], child2);
+        sprawl.remove_child(node, child1).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 1);
+        assert_eq!(sprawl.children(node).unwrap()[0], child2);
 
-        stretch.remove_child(node, child2).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 0);
+        sprawl.remove_child(node, child2).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 0);
     }
 
     #[test]
     fn remove_child_at_index() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
 
-        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 2);
+        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 2);
 
-        stretch.remove_child_at_index(node, 0).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 1);
-        assert_eq!(stretch.children(node).unwrap()[0], child2);
+        sprawl.remove_child_at_index(node, 0).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 1);
+        assert_eq!(sprawl.children(node).unwrap()[0], child2);
 
-        stretch.remove_child_at_index(node, 0).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 0);
+        sprawl.remove_child_at_index(node, 0).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 0);
     }
 
     #[test]
     fn replace_child_at_index() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
 
-        let node = stretch.new_node(Style::default(), &[child1]).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 1);
-        assert_eq!(stretch.children(node).unwrap()[0], child1);
+        let node = sprawl.new_node(Style::default(), &[child1]).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 1);
+        assert_eq!(sprawl.children(node).unwrap()[0], child1);
 
-        stretch.replace_child_at_index(node, 0, child2).unwrap();
-        assert_eq!(stretch.child_count(node).unwrap(), 1);
-        assert_eq!(stretch.children(node).unwrap()[0], child2);
+        sprawl.replace_child_at_index(node, 0, child2).unwrap();
+        assert_eq!(sprawl.child_count(node).unwrap(), 1);
+        assert_eq!(sprawl.children(node).unwrap()[0], child2);
     }
 
     #[test]
     fn remove() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
         let style2 = Style { flex_direction: FlexDirection::Column, ..Style::default() };
 
         // Build a linear tree layout: <0> <- <1> <- <2>
-        let node2 = stretch.new_node(style2, &[]).unwrap();
-        let node1 = stretch.new_node(Style::default(), &[node2]).unwrap();
-        let node0 = stretch.new_node(Style::default(), &[node1]).unwrap();
+        let node2 = sprawl.new_node(style2, &[]).unwrap();
+        let node1 = sprawl.new_node(Style::default(), &[node2]).unwrap();
+        let node0 = sprawl.new_node(Style::default(), &[node1]).unwrap();
 
-        assert_eq!(stretch.children(node0).unwrap().as_slice(), &[node1]);
+        assert_eq!(sprawl.children(node0).unwrap().as_slice(), &[node1]);
 
         // Disconnect the tree: <0> <2>
-        stretch.remove(node1);
+        sprawl.remove(node1);
 
-        assert!(stretch.style(node1).is_err());
+        assert!(sprawl.style(node1).is_err());
 
-        assert!(stretch.children(node0).unwrap().is_empty());
-        assert!(stretch.children(node2).unwrap().is_empty());
-        assert_eq!(stretch.style(node2).unwrap().flex_direction, style2.flex_direction);
+        assert!(sprawl.children(node0).unwrap().is_empty());
+        assert!(sprawl.children(node2).unwrap().is_empty());
+        assert_eq!(sprawl.style(node2).unwrap().flex_direction, style2.flex_direction);
     }
 
     #[test]
     fn set_children() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
-        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
 
-        assert_eq!(stretch.child_count(node).unwrap(), 2);
-        assert_eq!(stretch.children(node).unwrap()[0], child1);
-        assert_eq!(stretch.children(node).unwrap()[1], child2);
+        assert_eq!(sprawl.child_count(node).unwrap(), 2);
+        assert_eq!(sprawl.children(node).unwrap()[0], child1);
+        assert_eq!(sprawl.children(node).unwrap()[1], child2);
 
-        let child3 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child4 = stretch.new_node(Style::default(), &[]).unwrap();
-        stretch.set_children(node, &[child3, child4]).unwrap();
+        let child3 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child4 = sprawl.new_node(Style::default(), &[]).unwrap();
+        sprawl.set_children(node, &[child3, child4]).unwrap();
 
-        assert_eq!(stretch.child_count(node).unwrap(), 2);
-        assert_eq!(stretch.children(node).unwrap()[0], child3);
-        assert_eq!(stretch.children(node).unwrap()[1], child4);
+        assert_eq!(sprawl.child_count(node).unwrap(), 2);
+        assert_eq!(sprawl.children(node).unwrap()[0], child3);
+        assert_eq!(sprawl.children(node).unwrap()[1], child4);
     }
 
     #[test]
     fn set_style() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let node = stretch.new_node(Style::default(), &[]).unwrap();
-        assert_eq!(stretch.style(node).unwrap().display, Display::Flex);
+        let node = sprawl.new_node(Style::default(), &[]).unwrap();
+        assert_eq!(sprawl.style(node).unwrap().display, Display::Flex);
 
-        stretch.set_style(node, Style { display: Display::None, ..Style::default() }).unwrap();
-        assert_eq!(stretch.style(node).unwrap().display, Display::None);
+        sprawl.set_style(node, Style { display: Display::None, ..Style::default() }).unwrap();
+        assert_eq!(sprawl.style(node).unwrap().display, Display::None);
     }
 
     #[test]
     fn mark_dirty() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let child1 = stretch.new_node(Style::default(), &[]).unwrap();
-        let child2 = stretch.new_node(Style::default(), &[]).unwrap();
-        let node = stretch.new_node(Style::default(), &[child1, child2]).unwrap();
+        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(stretch.dirty(child1).unwrap(), false);
-        assert_eq!(stretch.dirty(child2).unwrap(), false);
-        assert_eq!(stretch.dirty(node).unwrap(), false);
+        assert_eq!(sprawl.dirty(child1).unwrap(), false);
+        assert_eq!(sprawl.dirty(child2).unwrap(), false);
+        assert_eq!(sprawl.dirty(node).unwrap(), false);
 
-        stretch.mark_dirty(node).unwrap();
-        assert_eq!(stretch.dirty(child1).unwrap(), false);
-        assert_eq!(stretch.dirty(child2).unwrap(), false);
-        assert_eq!(stretch.dirty(node).unwrap(), true);
+        sprawl.mark_dirty(node).unwrap();
+        assert_eq!(sprawl.dirty(child1).unwrap(), false);
+        assert_eq!(sprawl.dirty(child2).unwrap(), false);
+        assert_eq!(sprawl.dirty(node).unwrap(), true);
 
-        stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-        stretch.mark_dirty(child1).unwrap();
-        assert_eq!(stretch.dirty(child1).unwrap(), true);
-        assert_eq!(stretch.dirty(child2).unwrap(), false);
-        assert_eq!(stretch.dirty(node).unwrap(), true);
+        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        sprawl.mark_dirty(child1).unwrap();
+        assert_eq!(sprawl.dirty(child1).unwrap(), true);
+        assert_eq!(sprawl.dirty(child2).unwrap(), false);
+        assert_eq!(sprawl.dirty(node).unwrap(), true);
     }
 
     #[test]
     fn remove_last_node() {
-        let mut stretch = Sprawl::new();
+        let mut sprawl = Sprawl::new();
 
-        let parent = stretch.new_node(Style::default(), &[]).unwrap();
-        let child = stretch.new_node(Style::default(), &[]).unwrap();
-        stretch.add_child(parent, child).unwrap();
+        let parent = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child = sprawl.new_node(Style::default(), &[]).unwrap();
+        sprawl.add_child(parent, child).unwrap();
 
-        stretch.remove(child);
-        stretch.remove(parent);
+        sprawl.remove(child);
+        sprawl.remove(parent);
     }
 }

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -2,8 +2,8 @@ use sprawl::style::Dimension;
 
 #[test]
 fn relayout() {
-    let mut stretch = sprawl::Sprawl::new();
-    let node1 = stretch
+    let mut sprawl = sprawl::Sprawl::new();
+    let node1 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
@@ -12,7 +12,7 @@ fn relayout() {
             &[],
         )
         .unwrap();
-    let node0 = stretch
+    let node0 = sprawl
         .new_node(
             sprawl::style::Style {
                 align_self: sprawl::prelude::AlignSelf::Center,
@@ -23,7 +23,7 @@ fn relayout() {
             &[node1],
         )
         .unwrap();
-    let node = stretch
+    let node = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: Dimension::Percent(1f32), height: Dimension::Percent(1f32) },
@@ -33,7 +33,7 @@ fn relayout() {
         )
         .unwrap();
     println!("0:");
-    stretch
+    sprawl
         .compute_layout(
             node,
             sprawl::geometry::Size {
@@ -42,12 +42,12 @@ fn relayout() {
             },
         )
         .unwrap();
-    let initial = stretch.layout(node).unwrap().location;
-    let initial0 = stretch.layout(node0).unwrap().location;
-    let initial1 = stretch.layout(node1).unwrap().location;
+    let initial = sprawl.layout(node).unwrap().location;
+    let initial0 = sprawl.layout(node0).unwrap().location;
+    let initial1 = sprawl.layout(node1).unwrap().location;
     for i in 1..10 {
         println!("\n\n{i}:");
-        stretch
+        sprawl
             .compute_layout(
                 node,
                 sprawl::geometry::Size {
@@ -56,8 +56,8 @@ fn relayout() {
                 },
             )
             .unwrap();
-        assert_eq!(stretch.layout(node).unwrap().location, initial);
-        assert_eq!(stretch.layout(node0).unwrap().location, initial0);
-        assert_eq!(stretch.layout(node1).unwrap().location, initial1);
+        assert_eq!(sprawl.layout(node).unwrap().location, initial);
+        assert_eq!(sprawl.layout(node0).unwrap().location, initial0);
+        assert_eq!(sprawl.layout(node1).unwrap().location, initial1);
     }
 }

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -2,7 +2,7 @@ use sprawl::style::Dimension;
 
 #[test]
 fn relayout() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node1 = stretch
         .new_node(
             sprawl::style::Style {

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -4,8 +4,8 @@ mod root_constraints {
 
     #[test]
     fn root_with_percentage_size() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let node = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -18,13 +18,13 @@ mod root_constraints {
             )
             .unwrap();
 
-        stretch
+        sprawl
             .compute_layout(
                 node,
                 sprawl::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(200.0) },
             )
             .unwrap();
-        let layout = stretch.layout(node).unwrap();
+        let layout = sprawl.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 100.0);
         assert_eq!(layout.size.height, 200.0);
@@ -32,16 +32,16 @@ mod root_constraints {
 
     #[test]
     fn root_with_no_size() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let node = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
 
-        stretch
+        sprawl
             .compute_layout(
                 node,
                 sprawl::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(100.0) },
             )
             .unwrap();
-        let layout = stretch.layout(node).unwrap();
+        let layout = sprawl.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 0.0);
         assert_eq!(layout.size.height, 0.0);
@@ -49,8 +49,8 @@ mod root_constraints {
 
     #[test]
     fn root_with_larger_size() {
-        let mut stretch = sprawl::node::Sprawl::new();
-        let node = stretch
+        let mut sprawl = sprawl::node::Sprawl::new();
+        let node = sprawl
             .new_node(
                 sprawl::style::Style {
                     size: sprawl::geometry::Size {
@@ -63,13 +63,13 @@ mod root_constraints {
             )
             .unwrap();
 
-        stretch
+        sprawl
             .compute_layout(
                 node,
                 sprawl::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(100.0) },
             )
             .unwrap();
-        let layout = stretch.layout(node).unwrap();
+        let layout = sprawl.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 200.0);
         assert_eq!(layout.size.height, 200.0);

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -4,7 +4,7 @@ mod root_constraints {
 
     #[test]
     fn root_with_percentage_size() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let node = stretch
             .new_node(
                 sprawl::style::Style {
@@ -32,7 +32,7 @@ mod root_constraints {
 
     #[test]
     fn root_with_no_size() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let node = stretch.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
 
         stretch
@@ -49,7 +49,7 @@ mod root_constraints {
 
     #[test]
     fn root_with_larger_size() {
-        let mut stretch = sprawl::node::Stretch::new();
+        let mut stretch = sprawl::node::Sprawl::new();
         let node = stretch
             .new_node(
                 sprawl::style::Style {

--- a/tests/simple_child.rs
+++ b/tests/simple_child.rs
@@ -2,8 +2,8 @@ use sprawl::{geometry::Point, style::Dimension};
 
 #[test]
 fn simple_child() {
-    let mut stretch = sprawl::Sprawl::new();
-    let node0_0 = stretch
+    let mut sprawl = sprawl::Sprawl::new();
+    let node0_0 = sprawl
         .new_node(
             sprawl::style::Style {
                 align_self: sprawl::prelude::AlignSelf::Center,
@@ -13,7 +13,7 @@ fn simple_child() {
             &[],
         )
         .unwrap();
-    let node0 = stretch
+    let node0 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
@@ -22,7 +22,7 @@ fn simple_child() {
             &[node0_0],
         )
         .unwrap();
-    let node1_0 = stretch
+    let node1_0 = sprawl
         .new_node(
             sprawl::style::Style {
                 align_self: sprawl::prelude::AlignSelf::Center,
@@ -32,7 +32,7 @@ fn simple_child() {
             &[],
         )
         .unwrap();
-    let node1_1 = stretch
+    let node1_1 = sprawl
         .new_node(
             sprawl::style::Style {
                 align_self: sprawl::prelude::AlignSelf::Center,
@@ -42,7 +42,7 @@ fn simple_child() {
             &[],
         )
         .unwrap();
-    let node1 = stretch
+    let node1 = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: Dimension::Undefined, height: Dimension::Undefined },
@@ -51,7 +51,7 @@ fn simple_child() {
             &[node1_0, node1_1],
         )
         .unwrap();
-    let node = stretch
+    let node = sprawl
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: Dimension::Percent(100.0), height: Dimension::Percent(100.0) },
@@ -60,7 +60,7 @@ fn simple_child() {
             &[node0, node1],
         )
         .unwrap();
-    stretch
+    sprawl
         .compute_layout(
             node,
             sprawl::geometry::Size {
@@ -69,11 +69,11 @@ fn simple_child() {
             },
         )
         .unwrap();
-    assert_eq!(stretch.layout(node).unwrap().location, Point { x: 0.0, y: 0.0 });
-    assert_eq!(stretch.layout(node0).unwrap().location, Point { x: 0.0, y: 0.0 });
-    assert_eq!(stretch.layout(node1).unwrap().location, Point { x: 10.0, y: 0.0 });
-    assert_eq!(stretch.layout(node0_0).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(sprawl.layout(node).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(sprawl.layout(node0).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(sprawl.layout(node1).unwrap().location, Point { x: 10.0, y: 0.0 });
+    assert_eq!(sprawl.layout(node0_0).unwrap().location, Point { x: 0.0, y: 0.0 });
     // Layout is relative so node1_0 location starts at (0,0) and is not ofset by it's parent location
-    assert_eq!(stretch.layout(node1_0).unwrap().location, Point { x: 00.0, y: 0.0 });
-    assert_eq!(stretch.layout(node1_1).unwrap().location, Point { x: 10.0, y: 0.0 });
+    assert_eq!(sprawl.layout(node1_0).unwrap().location, Point { x: 00.0, y: 0.0 });
+    assert_eq!(sprawl.layout(node1_1).unwrap().location, Point { x: 10.0, y: 0.0 });
 }

--- a/tests/simple_child.rs
+++ b/tests/simple_child.rs
@@ -2,7 +2,7 @@ use sprawl::{geometry::Point, style::Dimension};
 
 #[test]
 fn simple_child() {
-    let mut stretch = sprawl::Stretch::new();
+    let mut stretch = sprawl::Sprawl::new();
     let node0_0 = stretch
         .new_node(
             sprawl::style::Style {


### PR DESCRIPTION
# Objective

Fixes #78 

## Context

This was simply done with a rename using a rust-analyzer

## Feedback wanted

What is responsible for generating these generated scripts? There's a whole lot of 
```rust
let mut stretch = sprawl::Sprawl::new();
````
which should probably be renamed to `let mut sprawl` for consistency but I'd like to change this at the source where it is generated if possible.

## Migration Guide

- Rename all references of `sprawl::node::Stretch` to `sprawl::node::Sprawl`
