### PR TITLE
Remove serde_camel_case and serde_kebab_case features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,6 @@ optional = true
 default = ["std"]
 alloc = ["hashbrown"]
 std = ["num-traits/std"]
-serde_camel_case = ["serde"]
-serde_kebab_case = ["serde"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,7 @@
   - the maintainer team lacks expertise to keep these working
   - more serious refactors are planned, and this will be challenging to keep working through that process
   - if you are interested in helping us maintain bindings to other languages, [get in touch](https://github.com/DioxusLabs/sprawl/discussions)!
+- the `serde_camel_case` and `serde_kebab_case` features have been removed: they were poorly motivated and were not correctly additive (if both were enabled compilation would fail)
 
 ## stretch2 0.4.3
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -6,8 +6,6 @@ use crate::style::{Dimension, FlexDirection};
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub struct Rect<T> {
     pub start: T,
     pub end: T,
@@ -105,8 +103,6 @@ where
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub struct Size<T> {
     pub width: T,
     pub height: T,

--- a/src/number.rs
+++ b/src/number.rs
@@ -2,8 +2,6 @@ use core::ops::{Add, Div, Mul, Sub};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum Number {
     Defined(f32),
     Undefined,

--- a/src/style.rs
+++ b/src/style.rs
@@ -3,8 +3,6 @@ use crate::number::Number;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum AlignItems {
     FlexStart,
     FlexEnd,
@@ -21,8 +19,6 @@ impl Default for AlignItems {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum AlignSelf {
     Auto,
     FlexStart,
@@ -40,8 +36,6 @@ impl Default for AlignSelf {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum AlignContent {
     FlexStart,
     FlexEnd,
@@ -59,8 +53,6 @@ impl Default for AlignContent {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum Direction {
     Inherit,
     #[cfg_attr(feature = "serde", serde(rename = "ltr"))]
@@ -77,8 +69,6 @@ impl Default for Direction {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum Display {
     #[cfg_attr(feature = "serde", serde(rename = "flex"))]
     Flex,
@@ -94,8 +84,6 @@ impl Default for Display {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum FlexDirection {
     Row,
     Column,
@@ -128,8 +116,6 @@ impl FlexDirection {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum JustifyContent {
     FlexStart,
     FlexEnd,
@@ -147,8 +133,6 @@ impl Default for JustifyContent {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum Overflow {
     Visible,
     Hidden,
@@ -163,8 +147,6 @@ impl Default for Overflow {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum PositionType {
     Relative,
     Absolute,
@@ -178,8 +160,6 @@ impl Default for PositionType {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum FlexWrap {
     NoWrap,
     Wrap,
@@ -194,8 +174,6 @@ impl Default for FlexWrap {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub enum Dimension {
     Undefined,
     Auto,
@@ -238,8 +216,6 @@ impl Default for Size<Dimension> {
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
-#[cfg_attr(all(feature = "serde", feature = "serde_kebab_case"), serde(rename_all = "kebab-case"))]
-#[cfg_attr(all(feature = "serde", feature = "serde_camel_case"), serde(rename_all = "camelCase"))]
 pub struct Style {
     pub display: Display,
     pub position_type: PositionType,


### PR DESCRIPTION
# Objective

- these features are not correctly additive: enabling both features at once will break compilation
 - Rust analyzer is correctly complaining about duplicate attributes
- these features are poorly motivated
 - presumably this is for cross-language serialization?
 - renaming like this is easily handled by external batch processing if needed 

## Migration Guide

If you were using these features, rename your generated serialization files manually (and get in touch to explain why you cared).