### PR TITLE
Make alloc and std compatible features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,14 @@ hash32-derive = "0.1"
 heapless = "0.7"
 num-traits = { version = "0.2", default-features = false }
 typenum = "1"
-
-[dependencies.hashbrown]
-version = "0.12"
-optional = true
-
-[dependencies.serde]
-version = "1.0"
-features = ["serde_derive"]
-optional = true
+hashbrown = {version = "0.12", optional = true}
+serde = {version = "1.0", optional = true, features = ["serde_derive"]}
 
 [features]
 default = ["std"]
 alloc = ["hashbrown"]
 std = ["num-traits/std"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,11 @@
 
 - renamed crate from `stretch2` to `sprawl`
 - updated to the latest version of all dependencies to reduce upstream pain caused by duplicate dependencies
-- Renamed `sprawl::node::Strech` -> `sprawl::node::Sprawl`
+- Renamed `stretch::node::Strech` -> `sprawl::node::Sprawl`
+
+### Fixed
+
+- fixed feature strategy for `alloc` and `std`: these can now be compiled together, with `std`'s types taking priority
 
 ### Removed
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -12,15 +12,15 @@ pub use self::core::*;
 
 #[cfg(feature = "std")]
 mod std {
-    pub type Box<A> = ::std::boxed::Box<A>;
-    pub type Map<K, V> = ::std::collections::HashMap<K, V>;
-    pub type Vec<A> = ::std::vec::Vec<A>;
-    pub type ChildrenVec<A> = ::std::vec::Vec<A>;
-    pub type ParentsVec<A> = ::std::vec::Vec<A>;
+    pub type Box<A> = std::boxed::Box<A>;
+    pub type Map<K, V> = std::collections::HashMap<K, V>;
+    pub type Vec<A> = std::vec::Vec<A>;
+    pub type ChildrenVec<A> = std::vec::Vec<A>;
+    pub type ParentsVec<A> = std::vec::Vec<A>;
 
     pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V>
     where
-        K: Eq + ::std::hash::Hash,
+        K: Eq + std::hash::Hash,
     {
         Map::with_capacity(capacity)
     }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -42,11 +42,13 @@ mod std_data_types {
 
 #[cfg(feature = "alloc")]
 mod alloc_data_types {
-    pub type Box<A> = ::alloc::boxed::Box<A>;
-    pub type Map<K, V> = ::hashbrown::HashMap<K, V>;
-    pub type Vec<A> = ::alloc::vec::Vec<A>;
-    pub type ChildrenVec<A> = ::alloc::vec::Vec<A>;
-    pub type ParentsVec<A> = ::alloc::vec::Vec<A>;
+    extern crate alloc;
+
+    type Box<A> = alloc::boxed::Box<A>;
+    type Map<K, V> = hashbrown::HashMap<K, V>;
+    type Vec<A> = alloc::vec::Vec<A>;
+    type ChildrenVec<A> = alloc::vec::Vec<A>;
+    type ParentsVec<A> = alloc::vec::Vec<A>;
 
     fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
         Map::with_capacity(capacity)

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -4,7 +4,7 @@ pub use self::std::*;
 
 // When alloc but not std is enabled, use those types
 #[cfg(all(feature = "alloc", not(feature = "std")))]
-pub use alloc::*;
+pub use self::alloc::*;
 
 // When neither alloc or std is enabled, use a heapless fallback
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,17 +1,17 @@
 // When std is enabled, prefer those types
 #[cfg(feature = "std")]
-pub use std_data_types::*;
+pub use self::std::*;
 
 // When alloc but not std is enabled, use those types
 #[cfg(all(feature = "alloc", not(feature = "std")))]
-pub use alloc_data_types::*;
+pub use alloc::*;
 
 // When neither alloc or std is enabled, use a heapless fallback
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]
-pub use core_data_types::*;
+pub use self::core::*;
 
 #[cfg(feature = "std")]
-mod std_data_types {
+mod std {
     pub type Box<A> = ::std::boxed::Box<A>;
     pub type Map<K, V> = ::std::collections::HashMap<K, V>;
     pub type Vec<A> = ::std::vec::Vec<A>;
@@ -40,59 +40,59 @@ mod std_data_types {
     }
 }
 
-#[cfg(feature = "alloc")]
-mod alloc_data_types {
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+mod alloc {
     extern crate alloc;
 
-    type Box<A> = alloc::boxed::Box<A>;
-    type Map<K, V> = hashbrown::HashMap<K, V>;
-    type Vec<A> = alloc::vec::Vec<A>;
-    type ChildrenVec<A> = alloc::vec::Vec<A>;
-    type ParentsVec<A> = alloc::vec::Vec<A>;
+    pub type Box<A> = alloc::boxed::Box<A>;
+    pub type Map<K, V> = hashbrown::HashMap<K, V>;
+    pub type Vec<A> = alloc::vec::Vec<A>;
+    pub type ChildrenVec<A> = alloc::vec::Vec<A>;
+    pub type ParentsVec<A> = alloc::vec::Vec<A>;
 
-    fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
+    pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
         Map::with_capacity(capacity)
     }
 
-    fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
+    pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
     }
 
     #[inline]
-    fn round(value: f32) -> f32 {
+    pub fn round(value: f32) -> f32 {
         num_traits::float::FloatCore::round(value)
     }
 
     #[inline]
-    fn abs(value: f32) -> f32 {
+    pub fn abs(value: f32) -> f32 {
         num_traits::float::FloatCore::abs(value)
     }
 }
 
 #[cfg(all(not(feature = "alloc"), not(feature = "std")))]
-mod core_data_types {
-    const MAX_NODE_COUNT: usize = 256;
-    const MAX_CHILD_COUNT: usize = 16;
-    const MAX_PARENTS_COUNT: usize = 1;
+mod core {
+    pub const MAX_NODE_COUNT: usize = 256;
+    pub const MAX_CHILD_COUNT: usize = 16;
+    pub const MAX_PARENTS_COUNT: usize = 1;
 
-    type Map<K, V> = heapless::FnvIndexMap<K, V, MAX_NODE_COUNT>;
-    type Vec<A> = arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
-    type ChildrenVec<A> = arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
-    type ParentsVec<A> = arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
+    pub type Map<K, V> = heapless::FnvIndexMap<K, V, MAX_NODE_COUNT>;
+    pub type Vec<A> = arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
+    pub type ChildrenVec<A> = arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
+    pub type ParentsVec<A> = arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
 
-    fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
+    pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where
         K: Eq + ::hash32::Hash,
     {
         Map::new()
     }
 
-    fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
+    pub fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
         arrayvec::ArrayVec::new()
     }
 
     #[inline]
-    fn round(value: f32) -> f32 {
+    pub fn round(value: f32) -> f32 {
         num_traits::float::FloatCore::round(value)
     }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -75,10 +75,10 @@ mod core_data_types {
     const MAX_CHILD_COUNT: usize = 16;
     const MAX_PARENTS_COUNT: usize = 1;
 
-    type Map<K, V> = ::heapless::FnvIndexMap<K, V, MAX_NODE_COUNT>;
-    type Vec<A> = ::arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
-    type ChildrenVec<A> = ::arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
-    type ParentsVec<A> = ::arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
+    type Map<K, V> = heapless::FnvIndexMap<K, V, MAX_NODE_COUNT>;
+    type Vec<A> = arrayvec::ArrayVec<A, MAX_NODE_COUNT>;
+    type ChildrenVec<A> = arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
+    type ParentsVec<A> = arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
 
     fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where
@@ -87,8 +87,8 @@ mod core_data_types {
         Map::new()
     }
 
-    fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> ::arrayvec::ArrayVec<A, CAP> {
-        ::arrayvec::ArrayVec::new()
+    fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
+        arrayvec::ArrayVec::new()
     }
 
     #[inline]


### PR DESCRIPTION
# Objective

- alloc and std were not compatible
  - this led to some very noisy error messages in rust-analyzer
  - fixes #85
- `std` will be preferred over `alloc` if both are present