### PR TITLE
Remove migration guide from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,9 +19,3 @@ This may include related issues, previous discussion, or links to documentation 
 Which parts of this PR were you unsure about? Which parts were particularly tricky?
 
 If you're stuck on part of the changes or want feedback early, open a draft PR and list the items that need to be completed here using a [checklist](https://github.blog/2014-04-28-task-lists-in-all-markdown-documents/).
-
-## Migration Guide
-
-> This section is optional. If there are no breaking changes, you can delete this section.
-
-If this PR is a breaking change (relative to the last release of this library), describe how a user might need to migrate their code to support these changes


### PR DESCRIPTION
# Objective

- the Migration Guide section of the PR template is redundant to RELEASES,md
- we should have a single source of truth