### PR TITLE
Make order field of `Layout` pub

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,17 +2,18 @@
 
 ## 0.1.0
 
-### Changed
+### 0.1.0 Changed
 
+- the `order` field of `Layout` is now public, and describes the relative z-ordering of nodes
 - renamed crate from `stretch2` to `sprawl`
 - updated to the latest version of all dependencies to reduce upstream pain caused by duplicate dependencies
 - Renamed `stretch::node::Strech` -> `sprawl::node::Sprawl`
 
-### Fixed
+### 0.1.0 Fixed
 
 - fixed feature strategy for `alloc` and `std`: these can now be compiled together, with `std`'s types taking priority
 
-### Removed
+### 0.1.0 Removed
 
 - removed Javascript / Kotlin / Swift bindings
   - the maintainer team lacks expertise to keep these working
@@ -22,7 +23,7 @@
 
 ## stretch2 0.4.3
 
-This is the final release of `sprawl`: migrate to the crate named `sprawl` for future fixes and features!
+This is the final release of `stretch`: migrate to the crate named `sprawl` for future fixes and features!
 
 These notes describe the differences between this release and `stretch` 0.3.2, the abandoned crate from which this library was forked.
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -2,11 +2,17 @@ use crate::algo::ComputeResult;
 use crate::geometry::{Point, Size};
 use crate::number::Number;
 
+/// The final result of a layout algorithm for a single [`Node`](crate::node::Node).
 #[derive(Copy, Debug, Clone)]
 pub struct Layout {
-    #[allow(dead_code)]
-    pub(crate) order: u32,
+    /// The relative ordering of the node
+    ///
+    /// Nodes with a higher order should be rendered on top of those with a lower order.
+    /// This is effectively a topological sort of each tree.
+    pub order: u32,
+    // The width and height of the node
     pub size: Size<f32>,
+    // The bottom-left corner of the node
     pub location: Point<f32>,
 }
 


### PR DESCRIPTION
# Objective

- this code is marked dead, but is written to with actual values
- based on examination of the code, this appears to actually be useful information about the relative z-ordering of the fields
- make this pub, which eliminates the need for the `#[allow(dead_code)]` annotation
- add basic docs
- fixes #93