### PR TITLE
Remove dead Direction type

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,6 +20,8 @@
   - more serious refactors are planned, and this will be challenging to keep working through that process
   - if you are interested in helping us maintain bindings to other languages, [get in touch](https://github.com/DioxusLabs/sprawl/discussions)!
 - the `serde_camel_case` and `serde_kebab_case` features have been removed: they were poorly motivated and were not correctly additive (if both were enabled compilation would fail)
+- removed the `Direction` struct, and the corresponding `direction` field from `Style`
+  - this had no effect in the current code base and was actively misleading
 
 ## stretch2 0.4.3
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,8 @@ pub use crate::{
     node::{Node, Sprawl},
     number::Number,
     style::{
-        AlignContent, AlignItems, AlignSelf, Dimension, Direction, Display, FlexDirection, FlexWrap, JustifyContent,
-        Overflow, PositionType, Style,
+        AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, JustifyContent, Overflow,
+        PositionType, Style,
     },
     Error,
 };

--- a/src/style.rs
+++ b/src/style.rs
@@ -53,22 +53,6 @@ impl Default for AlignContent {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Direction {
-    Inherit,
-    #[cfg_attr(feature = "serde", serde(rename = "ltr"))]
-    LTR,
-    #[cfg_attr(feature = "serde", serde(rename = "rtl"))]
-    RTL,
-}
-
-impl Default for Direction {
-    fn default() -> Self {
-        Self::Inherit
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Display {
     #[cfg_attr(feature = "serde", serde(rename = "flex"))]
     Flex,
@@ -219,7 +203,6 @@ impl Default for Size<Dimension> {
 pub struct Style {
     pub display: Display,
     pub position_type: PositionType,
-    pub direction: Direction,
     pub flex_direction: FlexDirection,
     pub flex_wrap: FlexWrap,
     pub overflow: Overflow,
@@ -245,7 +228,6 @@ impl Default for Style {
         Self {
             display: Default::default(),
             position_type: Default::default(),
-            direction: Default::default(),
             flex_direction: Default::default(),
             flex_wrap: Default::default(),
             overflow: Default::default(),


### PR DESCRIPTION
# Objective

Fixes #110, noticed in #96.

Documenting that the field does nothing seems incorrect, and adding behavior to fix it is out of scope for the initial release.