### PR TITLE
Remove dead Overflow type

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,7 +20,7 @@
   - more serious refactors are planned, and this will be challenging to keep working through that process
   - if you are interested in helping us maintain bindings to other languages, [get in touch](https://github.com/DioxusLabs/sprawl/discussions)!
 - the `serde_camel_case` and `serde_kebab_case` features have been removed: they were poorly motivated and were not correctly additive (if both were enabled compilation would fail)
-- removed the `Direction` and `Overflow` struct, and the corresponding `direction` and `overflow` fields from `Style`
+- removed the `Direction` and `Overflow` structs, and the corresponding `direction` and `overflow` fields from `Style`
   - these had no effect in the current code base and were actively misleading
 
 ## stretch2 0.4.3

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,8 +20,8 @@
   - more serious refactors are planned, and this will be challenging to keep working through that process
   - if you are interested in helping us maintain bindings to other languages, [get in touch](https://github.com/DioxusLabs/sprawl/discussions)!
 - the `serde_camel_case` and `serde_kebab_case` features have been removed: they were poorly motivated and were not correctly additive (if both were enabled compilation would fail)
-- removed the `Direction` struct, and the corresponding `direction` field from `Style`
-  - this had no effect in the current code base and was actively misleading
+- removed the `Direction` and `Overflow` struct, and the corresponding `direction` and `overflow` fields from `Style`
+  - these had no effect in the current code base and were actively misleading
 
 ## stretch2 0.4.3
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,8 @@ pub use crate::{
     node::{Node, Sprawl},
     number::Number,
     style::{
-        AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, JustifyContent, Overflow,
-        PositionType, Style,
+        AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, JustifyContent, PositionType,
+        Style,
     },
     Error,
 };

--- a/src/style.rs
+++ b/src/style.rs
@@ -117,20 +117,6 @@ impl Default for JustifyContent {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Overflow {
-    Visible,
-    Hidden,
-    Scroll,
-}
-
-impl Default for Overflow {
-    fn default() -> Self {
-        Self::Visible
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PositionType {
     Relative,
     Absolute,
@@ -205,7 +191,6 @@ pub struct Style {
     pub position_type: PositionType,
     pub flex_direction: FlexDirection,
     pub flex_wrap: FlexWrap,
-    pub overflow: Overflow,
     pub align_items: AlignItems,
     pub align_self: AlignSelf,
     pub align_content: AlignContent,
@@ -230,7 +215,6 @@ impl Default for Style {
             position_type: Default::default(),
             flex_direction: Default::default(),
             flex_wrap: Default::default(),
-            overflow: Default::default(),
             align_items: Default::default(),
             align_self: Default::default(),
             align_content: Default::default(),


### PR DESCRIPTION
# Objective

Just like in #111, this code is completely dead.

It should be removed, rather than misleading users.