### PR TITLE
Geometry Rect improvements

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 ### 0.1.0 Changed
 
+- the fields of `Rect<T>` has been renamed to adhere to flexbox specifications
 - the `order` field of `Layout` is now public, and describes the relative z-ordering of nodes
 - renamed crate from `stretch2` to `sprawl`
 - updated to the latest version of all dependencies to reduce upstream pain caused by duplicate dependencies

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
+                    main_start: sprawl::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -9,7 +9,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(5f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(5f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -9,7 +9,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -10,7 +10,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.5f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,7 +28,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Percent(0.5f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,8 +42,8 @@ pub fn compute() {
                 position_type: sprawl::style::PositionType::Absolute,
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
                 position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_start_top_end_bottom.rs
@@ -5,10 +5,10 @@ pub fn compute() {
             sprawl::style::Style {
                 position_type: sprawl::style::PositionType::Absolute,
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_width_height_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_end_bottom.rs
@@ -10,8 +10,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_width_height_start_top.rs
+++ b/benches/generated/absolute_layout_width_height_start_top.rs
@@ -10,8 +10,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/absolute_layout_within_border.rs
+++ b/benches/generated/absolute_layout_within_border.rs
@@ -10,8 +10,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                    main_start: sprawl::style::Dimension::Points(0f32),
+                    cross_start: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,8 +29,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                    main_end: sprawl::style::Dimension::Points(0f32),
+                    cross_end: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -48,15 +48,15 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                    main_start: sprawl::style::Dimension::Points(0f32),
+                    cross_start: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -74,15 +74,15 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                    main_end: sprawl::style::Dimension::Points(0f32),
+                    cross_end: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -99,17 +99,17 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/align_items_center_with_child_margin.rs
+++ b/benches/generated/align_items_center_with_child_margin.rs
@@ -8,7 +8,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/align_items_center_with_child_top.rs
+++ b/benches/generated/align_items_center_with_child_top.rs
@@ -8,7 +8,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/border_center_child.rs
+++ b/benches/generated/border_center_child.rs
@@ -24,8 +24,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/border_flex_child.rs
+++ b/benches/generated/border_flex_child.rs
@@ -19,10 +19,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/border_no_child.rs
+++ b/benches/generated/border_no_child.rs
@@ -4,10 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/border_stretch_child.rs
+++ b/benches/generated/border_stretch_child.rs
@@ -18,10 +18,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/display_none_with_margin.rs
+++ b/benches/generated/display_none_with_margin.rs
@@ -10,10 +10,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/display_none_with_position.rs
+++ b/benches/generated/display_none_with_position.rs
@@ -6,7 +6,10 @@ pub fn compute() {
             sprawl::style::Style {
                 display: sprawl::style::Display::None,
                 flex_grow: 1f32,
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -8,7 +8,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(100f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_top.rs
@@ -8,7 +8,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -22,8 +22,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                    main_start: sprawl::style::Dimension::Points(100f32),
+                    main_end: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -22,8 +22,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                    main_start: sprawl::style::Dimension::Points(100f32),
+                    main_end: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/justify_content_row_max_width_and_margin.rs
+++ b/benches/generated/justify_content_row_max_width_and_margin.rs
@@ -9,7 +9,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
+                    main_start: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/justify_content_row_min_width_and_margin.rs
+++ b/benches/generated/justify_content_row_min_width_and_margin.rs
@@ -8,7 +8,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_and_flex_column.rs
+++ b/benches/generated/margin_and_flex_column.rs
@@ -5,8 +5,8 @@ pub fn compute() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_and_flex_row.rs
+++ b/benches/generated/margin_and_flex_row.rs
@@ -5,8 +5,8 @@ pub fn compute() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_and_stretch_column.rs
+++ b/benches/generated/margin_and_stretch_column.rs
@@ -5,8 +5,8 @@ pub fn compute() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_and_stretch_row.rs
+++ b/benches/generated/margin_and_stretch_row.rs
@@ -5,8 +5,8 @@ pub fn compute() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_bottom.rs
+++ b/benches/generated/margin_auto_bottom.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { bottom: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_bottom_and_top.rs
+++ b/benches/generated/margin_auto_bottom_and_top.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
+                    cross_start: sprawl::style::Dimension::Auto,
+                    cross_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/benches/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
+                    cross_start: sprawl::style::Dimension::Auto,
+                    cross_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left.rs
+++ b/benches/generated/margin_auto_left.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_left_and_right.rs
+++ b/benches/generated/margin_auto_left_and_right.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left_and_right_column.rs
+++ b/benches/generated/margin_auto_left_and_right_column.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/benches/generated/margin_auto_left_and_right_column_and_center.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left_and_right_strech.rs
+++ b/benches/generated/margin_auto_left_and_right_strech.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_left_stretching_child.rs
+++ b/benches/generated/margin_auto_left_stretching_child.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
                 flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_mutiple_children_column.rs
+++ b/benches/generated/margin_auto_mutiple_children_column.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
@@ -22,7 +22,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_mutiple_children_row.rs
+++ b/benches/generated/margin_auto_mutiple_children_row.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
@@ -22,7 +22,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_right.rs
+++ b/benches/generated/margin_auto_right.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_top.rs
+++ b/benches/generated/margin_auto_top.rs
@@ -8,7 +8,7 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_auto_top_and_bottom_strech.rs
+++ b/benches/generated/margin_auto_top_and_bottom_strech.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
+                    cross_start: sprawl::style::Dimension::Auto,
+                    cross_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_auto_top_stretching_child.rs
+++ b/benches/generated/margin_auto_top_stretching_child.rs
@@ -6,7 +6,7 @@ pub fn compute() {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
                 flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -5,7 +5,7 @@ pub fn compute() {
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
                 margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_left.rs
+++ b/benches/generated/margin_left.rs
@@ -4,7 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -4,7 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_should_not_be_part_of_max_height.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_height.rs
@@ -12,7 +12,10 @@ pub fn compute() {
                     height: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_should_not_be_part_of_max_width.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_width.rs
@@ -12,7 +12,10 @@ pub fn compute() {
                     width: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_top.rs
+++ b/benches/generated/margin_top.rs
@@ -4,7 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/margin_with_sibling_column.rs
+++ b/benches/generated/margin_with_sibling_column.rs
@@ -5,7 +5,7 @@ pub fn compute() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/margin_with_sibling_row.rs
+++ b/benches/generated/margin_with_sibling_row.rs
@@ -4,7 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -9,10 +9,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/padding_center_child.rs
+++ b/benches/generated/padding_center_child.rs
@@ -24,10 +24,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/padding_flex_child.rs
+++ b/benches/generated/padding_flex_child.rs
@@ -19,10 +19,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/padding_no_child.rs
+++ b/benches/generated/padding_no_child.rs
@@ -4,10 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/padding_stretch_child.rs
+++ b/benches/generated/padding_stretch_child.rs
@@ -18,10 +18,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percent_absolute_position.rs
+++ b/benches/generated/percent_absolute_position.rs
@@ -28,7 +28,7 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.5f32),
+                    main_start: sprawl::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_absolute_position.rs
+++ b/benches/generated/percentage_absolute_position.rs
@@ -10,8 +10,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.3f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
+                    main_start: sprawl::style::Dimension::Percent(0.3f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -19,10 +19,10 @@ pub fn compute() {
                 flex_direction: sprawl::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    main_start: sprawl::style::Dimension::Percent(0.1f32),
+                    main_end: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -8,17 +8,17 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.05f32),
-                    end: sprawl::style::Dimension::Percent(0.05f32),
-                    top: sprawl::style::Dimension::Percent(0.05f32),
-                    bottom: sprawl::style::Dimension::Percent(0.05f32),
+                    main_start: sprawl::style::Dimension::Percent(0.05f32),
+                    main_end: sprawl::style::Dimension::Percent(0.05f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.05f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.05f32),
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                    main_start: sprawl::style::Dimension::Points(3f32),
+                    main_end: sprawl::style::Dimension::Points(3f32),
+                    cross_start: sprawl::style::Dimension::Points(3f32),
+                    cross_end: sprawl::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,17 +32,17 @@ pub fn compute() {
                 flex_direction: sprawl::style::FlexDirection::Column,
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(0.5f32), ..Default::default() },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+                    main_start: sprawl::style::Dimension::Points(5f32),
+                    main_end: sprawl::style::Dimension::Points(5f32),
+                    cross_start: sprawl::style::Dimension::Points(5f32),
+                    cross_end: sprawl::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.03f32),
-                    end: sprawl::style::Dimension::Percent(0.03f32),
-                    top: sprawl::style::Dimension::Percent(0.03f32),
-                    bottom: sprawl::style::Dimension::Percent(0.03f32),
+                    main_start: sprawl::style::Dimension::Percent(0.03f32),
+                    main_end: sprawl::style::Dimension::Percent(0.03f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.03f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.03f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -61,17 +61,17 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+                    main_start: sprawl::style::Dimension::Points(5f32),
+                    main_end: sprawl::style::Dimension::Points(5f32),
+                    cross_start: sprawl::style::Dimension::Points(5f32),
+                    cross_end: sprawl::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                    main_start: sprawl::style::Dimension::Points(3f32),
+                    main_end: sprawl::style::Dimension::Points(3f32),
+                    cross_start: sprawl::style::Dimension::Points(3f32),
+                    cross_end: sprawl::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -19,10 +19,10 @@ pub fn compute() {
                 flex_direction: sprawl::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    main_start: sprawl::style::Dimension::Percent(0.1f32),
+                    main_end: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_position_bottom_right.rs
+++ b/benches/generated/percentage_position_bottom_right.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Percent(0.2f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    main_end: sprawl::style::Dimension::Percent(0.2f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_position_left_top.rs
+++ b/benches/generated/percentage_position_left_top.rs
@@ -9,8 +9,8 @@ pub fn compute() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.2f32),
+                    main_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/benches/generated/percentage_size_based_on_parent_inner_size.rs
@@ -23,10 +23,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/relative_position_should_not_nudge_siblings.rs
+++ b/benches/generated/relative_position_should_not_nudge_siblings.rs
@@ -4,7 +4,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(15f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],
@@ -14,7 +17,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(15f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/benches/generated/rounding_total_fractial_nested.rs
+++ b/benches/generated/rounding_total_fractial_nested.rs
@@ -7,7 +7,7 @@ pub fn compute() {
                 flex_basis: sprawl::style::Dimension::Points(0.3f32),
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(9.9f32), ..Default::default() },
                 position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(13.3f32),
+                    cross_end: sprawl::style::Dimension::Points(13.3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,7 +22,7 @@ pub fn compute() {
                 flex_basis: sprawl::style::Dimension::Points(0.3f32),
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(1.1f32), ..Default::default() },
                 position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(13.3f32),
+                    cross_start: sprawl::style::Dimension::Points(13.3f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/size_defined_by_child_with_border.rs
+++ b/benches/generated/size_defined_by_child_with_border.rs
@@ -17,10 +17,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/size_defined_by_child_with_padding.rs
+++ b/benches/generated/size_defined_by_child_with_padding.rs
@@ -17,10 +17,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -36,7 +36,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[node010],

--- a/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -36,7 +36,10 @@ pub fn compute() {
         .new_node(
             sprawl::style::Style {
                 flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[node010],

--- a/benches/generated/wrapped_column_max_height.rs
+++ b/benches/generated/wrapped_column_max_height.rs
@@ -26,10 +26,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/benches/generated/wrapped_column_max_height_flex.rs
+++ b/benches/generated/wrapped_column_max_height_flex.rs
@@ -32,10 +32,10 @@ pub fn compute() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -189,10 +189,10 @@ impl Forest {
         let border = self.nodes[node].style.border.map(|n| n.resolve(parent_size.width).or_else(0.0));
 
         let padding_border = Rect {
-            start: padding.start + border.start,
-            end: padding.end + border.end,
-            top: padding.top + border.top,
-            bottom: padding.bottom + border.bottom,
+            main_start: padding.main_start + border.main_start,
+            main_end: padding.main_end + border.main_end,
+            cross_start: padding.cross_start + border.cross_start,
+            cross_end: padding.cross_end + border.cross_end,
         };
 
         let node_inner_size = Size {
@@ -1005,16 +1005,16 @@ impl Forest {
                     let child_style = &self.nodes[child.node].style;
                     if child_style.main_margin_start(constants.dir) == Dimension::Auto {
                         if constants.is_row {
-                            child.margin.start = margin;
+                            child.margin.main_start = margin;
                         } else {
-                            child.margin.top = margin;
+                            child.margin.cross_start = margin;
                         }
                     }
                     if child_style.main_margin_end(constants.dir) == Dimension::Auto {
                         if constants.is_row {
-                            child.margin.end = margin;
+                            child.margin.main_end = margin;
                         } else {
-                            child.margin.bottom = margin;
+                            child.margin.cross_end = margin;
                         }
                     }
                 }
@@ -1105,23 +1105,23 @@ impl Forest {
                     && child_style.cross_margin_end(constants.dir) == Dimension::Auto
                 {
                     if constants.is_row {
-                        child.margin.top = free_space / 2.0;
-                        child.margin.bottom = free_space / 2.0;
+                        child.margin.cross_start = free_space / 2.0;
+                        child.margin.cross_end = free_space / 2.0;
                     } else {
-                        child.margin.start = free_space / 2.0;
-                        child.margin.end = free_space / 2.0;
+                        child.margin.main_start = free_space / 2.0;
+                        child.margin.main_end = free_space / 2.0;
                     }
                 } else if child_style.cross_margin_start(constants.dir) == Dimension::Auto {
                     if constants.is_row {
-                        child.margin.top = free_space;
+                        child.margin.cross_start = free_space;
                     } else {
-                        child.margin.start = free_space;
+                        child.margin.main_start = free_space;
                     }
                 } else if child_style.cross_margin_end(constants.dir) == Dimension::Auto {
                     if constants.is_row {
-                        child.margin.bottom = free_space;
+                        child.margin.cross_end = free_space;
                     } else {
-                        child.margin.end = free_space;
+                        child.margin.main_end = free_space;
                     }
                 } else {
                     // 14. Align all flex items along the cross-axis.
@@ -1367,14 +1367,14 @@ impl Forest {
 
             let child_style = self.nodes[child].style;
 
-            let start =
-                child_style.position.start.resolve(container_width) + child_style.margin.start.resolve(container_width);
-            let end =
-                child_style.position.end.resolve(container_width) + child_style.margin.end.resolve(container_width);
-            let top =
-                child_style.position.top.resolve(container_height) + child_style.margin.top.resolve(container_height);
-            let bottom = child_style.position.bottom.resolve(container_height)
-                + child_style.margin.bottom.resolve(container_height);
+            let start = child_style.position.main_start.resolve(container_width)
+                + child_style.margin.main_start.resolve(container_width);
+            let end = child_style.position.main_end.resolve(container_width)
+                + child_style.margin.main_end.resolve(container_width);
+            let top = child_style.position.cross_start.resolve(container_height)
+                + child_style.margin.cross_start.resolve(container_height);
+            let bottom = child_style.position.cross_end.resolve(container_height)
+                + child_style.margin.cross_end.resolve(container_height);
 
             let (start_main, end_main) = if constants.is_row { (start, end) } else { (top, bottom) };
             let (start_cross, end_cross) = if constants.is_row { (top, bottom) } else { (start, end) };

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -7,10 +7,10 @@ use crate::style::{Dimension, FlexDirection};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Rect<T> {
-    pub start: T,
-    pub end: T,
-    pub top: T,
-    pub bottom: T,
+    pub main_start: T,
+    pub main_end: T,
+    pub cross_start: T,
+    pub cross_end: T,
 }
 
 impl<T> Rect<T> {
@@ -18,7 +18,12 @@ impl<T> Rect<T> {
     where
         F: Fn(T) -> R,
     {
-        Rect { start: f(self.start), end: f(self.end), top: f(self.top), bottom: f(self.bottom) }
+        Rect {
+            main_start: f(self.main_start),
+            main_end: f(self.main_end),
+            cross_start: f(self.cross_start),
+            cross_end: f(self.cross_end),
+        }
     }
     pub(crate) fn zip_size<R, F, U>(self, size: Size<U>, f: F) -> Rect<R>
     where
@@ -26,10 +31,10 @@ impl<T> Rect<T> {
         U: Copy,
     {
         Rect {
-            start: f(self.start, size.width),
-            end: f(self.end, size.width),
-            top: f(self.top, size.height),
-            bottom: f(self.bottom, size.height),
+            main_start: f(self.main_start, size.width),
+            main_end: f(self.main_end, size.width),
+            cross_start: f(self.cross_start, size.height),
+            cross_end: f(self.cross_end, size.height),
         }
     }
 }
@@ -39,11 +44,11 @@ where
     T: Add<Output = T> + Copy + Clone,
 {
     pub(crate) fn horizontal(&self) -> T {
-        self.start + self.end
+        self.main_start + self.main_end
     }
 
     pub(crate) fn vertical(&self) -> T {
-        self.top + self.bottom
+        self.cross_start + self.cross_end
     }
 
     pub(crate) fn main(&self, direction: FlexDirection) -> T {
@@ -69,33 +74,33 @@ where
 {
     pub(crate) fn main_start(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
-            self.start
+            self.main_start
         } else {
-            self.top
+            self.cross_start
         }
     }
 
     pub(crate) fn main_end(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
-            self.end
+            self.main_end
         } else {
-            self.bottom
+            self.cross_end
         }
     }
 
     pub(crate) fn cross_start(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
-            self.top
+            self.cross_start
         } else {
-            self.start
+            self.main_start
         }
     }
 
     pub(crate) fn cross_end(&self, direction: FlexDirection) -> T {
         if direction.is_row() {
-            self.bottom
+            self.cross_end
         } else {
-            self.end
+            self.main_end
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -173,7 +173,12 @@ impl Dimension {
 
 impl Default for Rect<Dimension> {
     fn default() -> Self {
-        Self { start: Default::default(), end: Default::default(), top: Default::default(), bottom: Default::default() }
+        Self {
+            main_start: Default::default(),
+            main_end: Default::default(),
+            cross_start: Default::default(),
+            cross_end: Default::default(),
+        }
     }
 }
 
@@ -253,17 +258,17 @@ impl Style {
 
     pub(crate) fn main_margin_start(&self, direction: FlexDirection) -> Dimension {
         if direction.is_row() {
-            self.margin.start
+            self.margin.main_start
         } else {
-            self.margin.top
+            self.margin.cross_start
         }
     }
 
     pub(crate) fn main_margin_end(&self, direction: FlexDirection) -> Dimension {
         if direction.is_row() {
-            self.margin.end
+            self.margin.main_end
         } else {
-            self.margin.bottom
+            self.margin.cross_end
         }
     }
 
@@ -293,17 +298,17 @@ impl Style {
 
     pub(crate) fn cross_margin_start(&self, direction: FlexDirection) -> Dimension {
         if direction.is_row() {
-            self.margin.top
+            self.margin.cross_start
         } else {
-            self.margin.start
+            self.margin.main_start
         }
     }
 
     pub(crate) fn cross_margin_end(&self, direction: FlexDirection) -> Dimension {
         if direction.is_row() {
-            self.margin.bottom
+            self.margin.cross_end
         } else {
-            self.margin.end
+            self.margin.main_end
         }
     }
 

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -11,7 +11,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -11,7 +11,7 @@ fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
+                    main_start: sprawl::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -10,7 +10,10 @@ fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
                     height: sprawl::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(5f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(5f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -10,7 +10,10 @@ fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
                     height: sprawl::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -11,7 +11,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.5f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,7 +29,7 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Percent(0.5f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,8 +43,8 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
                 position_type: sprawl::style::PositionType::Absolute,
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
                 position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_start_top_end_bottom.rs
@@ -6,10 +6,10 @@ fn absolute_layout_start_top_end_bottom() {
             sprawl::style::Style {
                 position_type: sprawl::style::PositionType::Absolute,
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_width_height_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_end_bottom.rs
@@ -11,8 +11,8 @@ fn absolute_layout_width_height_end_bottom() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_width_height_start_top.rs
+++ b/tests/generated/absolute_layout_width_height_start_top.rs
@@ -11,8 +11,8 @@ fn absolute_layout_width_height_start_top() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -11,10 +11,10 @@ fn absolute_layout_width_height_start_top_end_bottom() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/absolute_layout_within_border.rs
+++ b/tests/generated/absolute_layout_within_border.rs
@@ -11,8 +11,8 @@ fn absolute_layout_within_border() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                    main_start: sprawl::style::Dimension::Points(0f32),
+                    cross_start: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,8 +30,8 @@ fn absolute_layout_within_border() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                    main_end: sprawl::style::Dimension::Points(0f32),
+                    cross_end: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -49,15 +49,15 @@ fn absolute_layout_within_border() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                    main_start: sprawl::style::Dimension::Points(0f32),
+                    cross_start: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -75,15 +75,15 @@ fn absolute_layout_within_border() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                    main_end: sprawl::style::Dimension::Points(0f32),
+                    cross_end: sprawl::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -100,17 +100,17 @@ fn absolute_layout_within_border() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -10,8 +10,8 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/align_items_center_with_child_margin.rs
+++ b/tests/generated/align_items_center_with_child_margin.rs
@@ -9,7 +9,10 @@ fn align_items_center_with_child_margin() {
                     height: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/align_items_center_with_child_top.rs
+++ b/tests/generated/align_items_center_with_child_top.rs
@@ -9,7 +9,10 @@ fn align_items_center_with_child_top() {
                     height: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -10,8 +10,8 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/border_center_child.rs
+++ b/tests/generated/border_center_child.rs
@@ -25,8 +25,8 @@ fn border_center_child() {
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/border_flex_child.rs
+++ b/tests/generated/border_flex_child.rs
@@ -20,10 +20,10 @@ fn border_flex_child() {
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/border_no_child.rs
+++ b/tests/generated/border_no_child.rs
@@ -5,10 +5,10 @@ fn border_no_child() {
         .new_node(
             sprawl::style::Style {
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/border_stretch_child.rs
+++ b/tests/generated/border_stretch_child.rs
@@ -19,10 +19,10 @@ fn border_stretch_child() {
                     ..Default::default()
                 },
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/display_none_with_margin.rs
+++ b/tests/generated/display_none_with_margin.rs
@@ -11,10 +11,10 @@ fn display_none_with_margin() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/display_none_with_position.rs
+++ b/tests/generated/display_none_with_position.rs
@@ -7,7 +7,10 @@ fn display_none_with_position() {
             sprawl::style::Style {
                 display: sprawl::style::Display::None,
                 flex_grow: 1f32,
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -9,7 +9,10 @@ fn flex_shrink_by_outer_margin_with_max_size() {
                     height: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(100f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -10,7 +10,7 @@ fn justify_content_column_min_height_and_margin_bottom() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_top.rs
@@ -9,7 +9,10 @@ fn justify_content_column_min_height_and_margin_top() {
                     height: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -23,8 +23,8 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                    main_start: sprawl::style::Dimension::Points(100f32),
+                    main_end: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -23,8 +23,8 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                    main_start: sprawl::style::Dimension::Points(100f32),
+                    main_end: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/justify_content_row_max_width_and_margin.rs
+++ b/tests/generated/justify_content_row_max_width_and_margin.rs
@@ -10,7 +10,7 @@ fn justify_content_row_max_width_and_margin() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
+                    main_start: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/justify_content_row_min_width_and_margin.rs
+++ b/tests/generated/justify_content_row_min_width_and_margin.rs
@@ -9,7 +9,10 @@ fn justify_content_row_min_width_and_margin() {
                     height: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_and_flex_column.rs
+++ b/tests/generated/margin_and_flex_column.rs
@@ -6,8 +6,8 @@ fn margin_and_flex_column() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_and_flex_row.rs
+++ b/tests/generated/margin_and_flex_row.rs
@@ -6,8 +6,8 @@ fn margin_and_flex_row() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_and_stretch_column.rs
+++ b/tests/generated/margin_and_stretch_column.rs
@@ -6,8 +6,8 @@ fn margin_and_stretch_column() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_and_stretch_row.rs
+++ b/tests/generated/margin_and_stretch_row.rs
@@ -6,8 +6,8 @@ fn margin_and_stretch_row() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_bottom.rs
+++ b/tests/generated/margin_auto_bottom.rs
@@ -9,7 +9,7 @@ fn margin_auto_bottom() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { bottom: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_bottom_and_top.rs
+++ b/tests/generated/margin_auto_bottom_and_top.rs
@@ -10,8 +10,8 @@ fn margin_auto_bottom_and_top() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
+                    cross_start: sprawl::style::Dimension::Auto,
+                    cross_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/tests/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -10,8 +10,8 @@ fn margin_auto_bottom_and_top_justify_center() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
+                    cross_start: sprawl::style::Dimension::Auto,
+                    cross_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left.rs
+++ b/tests/generated/margin_auto_left.rs
@@ -9,7 +9,7 @@ fn margin_auto_left() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_left_and_right.rs
+++ b/tests/generated/margin_auto_left_and_right.rs
@@ -10,8 +10,8 @@ fn margin_auto_left_and_right() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left_and_right_column.rs
+++ b/tests/generated/margin_auto_left_and_right_column.rs
@@ -10,8 +10,8 @@ fn margin_auto_left_and_right_column() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/tests/generated/margin_auto_left_and_right_column_and_center.rs
@@ -10,8 +10,8 @@ fn margin_auto_left_and_right_column_and_center() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left_and_right_strech.rs
+++ b/tests/generated/margin_auto_left_and_right_strech.rs
@@ -10,8 +10,8 @@ fn margin_auto_left_and_right_strech() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -9,7 +9,7 @@ fn margin_auto_left_child_bigger_than_parent() {
                     height: sprawl::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -10,8 +10,8 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -10,8 +10,8 @@ fn margin_auto_left_right_child_bigger_than_parent() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Auto,
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_left_stretching_child.rs
+++ b/tests/generated/margin_auto_left_stretching_child.rs
@@ -7,7 +7,7 @@ fn margin_auto_left_stretching_child() {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
                 flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_mutiple_children_column.rs
+++ b/tests/generated/margin_auto_mutiple_children_column.rs
@@ -9,7 +9,7 @@ fn margin_auto_mutiple_children_column() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
@@ -23,7 +23,7 @@ fn margin_auto_mutiple_children_column() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_mutiple_children_row.rs
+++ b/tests/generated/margin_auto_mutiple_children_row.rs
@@ -9,7 +9,7 @@ fn margin_auto_mutiple_children_row() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
@@ -23,7 +23,7 @@ fn margin_auto_mutiple_children_row() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_right.rs
+++ b/tests/generated/margin_auto_right.rs
@@ -9,7 +9,7 @@ fn margin_auto_right() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { main_end: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_top.rs
+++ b/tests/generated/margin_auto_top.rs
@@ -9,7 +9,7 @@ fn margin_auto_top() {
                     height: sprawl::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_auto_top_and_bottom_strech.rs
+++ b/tests/generated/margin_auto_top_and_bottom_strech.rs
@@ -10,8 +10,8 @@ fn margin_auto_top_and_bottom_strech() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
+                    cross_start: sprawl::style::Dimension::Auto,
+                    cross_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_auto_top_stretching_child.rs
+++ b/tests/generated/margin_auto_top_stretching_child.rs
@@ -7,7 +7,7 @@ fn margin_auto_top_stretching_child() {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
                 flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: sprawl::geometry::Rect { cross_start: sprawl::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -6,7 +6,7 @@ fn margin_bottom() {
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
                 margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -10,8 +10,8 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Auto,
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_left.rs
+++ b/tests/generated/margin_left.rs
@@ -5,7 +5,10 @@ fn margin_left() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -5,7 +5,10 @@ fn margin_right() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_should_not_be_part_of_max_height.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_height.rs
@@ -13,7 +13,10 @@ fn margin_should_not_be_part_of_max_height() {
                     height: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_should_not_be_part_of_max_width.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_width.rs
@@ -13,7 +13,10 @@ fn margin_should_not_be_part_of_max_width() {
                     width: sprawl::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_top.rs
+++ b/tests/generated/margin_top.rs
@@ -5,7 +5,10 @@ fn margin_top() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/margin_with_sibling_column.rs
+++ b/tests/generated/margin_with_sibling_column.rs
@@ -6,7 +6,7 @@ fn margin_with_sibling_column() {
             sprawl::style::Style {
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/margin_with_sibling_row.rs
+++ b/tests/generated/margin_with_sibling_row.rs
@@ -5,7 +5,10 @@ fn margin_with_sibling_row() {
         .new_node(
             sprawl::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -10,10 +10,10 @@ fn padding_align_end_child() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/padding_center_child.rs
+++ b/tests/generated/padding_center_child.rs
@@ -25,10 +25,10 @@ fn padding_center_child() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/padding_flex_child.rs
+++ b/tests/generated/padding_flex_child.rs
@@ -20,10 +20,10 @@ fn padding_flex_child() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/padding_no_child.rs
+++ b/tests/generated/padding_no_child.rs
@@ -5,10 +5,10 @@ fn padding_no_child() {
         .new_node(
             sprawl::style::Style {
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/padding_stretch_child.rs
+++ b/tests/generated/padding_stretch_child.rs
@@ -19,10 +19,10 @@ fn padding_stretch_child() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percent_absolute_position.rs
+++ b/tests/generated/percent_absolute_position.rs
@@ -29,7 +29,7 @@ fn percent_absolute_position() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.5f32),
+                    main_start: sprawl::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_absolute_position.rs
+++ b/tests/generated/percentage_absolute_position.rs
@@ -11,8 +11,8 @@ fn percentage_absolute_position() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.3f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
+                    main_start: sprawl::style::Dimension::Percent(0.3f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -20,10 +20,10 @@ fn percentage_margin_should_calculate_based_only_on_width() {
                 flex_direction: sprawl::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    main_start: sprawl::style::Dimension::Percent(0.1f32),
+                    main_end: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -9,17 +9,17 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.05f32),
-                    end: sprawl::style::Dimension::Percent(0.05f32),
-                    top: sprawl::style::Dimension::Percent(0.05f32),
-                    bottom: sprawl::style::Dimension::Percent(0.05f32),
+                    main_start: sprawl::style::Dimension::Percent(0.05f32),
+                    main_end: sprawl::style::Dimension::Percent(0.05f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.05f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.05f32),
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                    main_start: sprawl::style::Dimension::Points(3f32),
+                    main_end: sprawl::style::Dimension::Points(3f32),
+                    cross_start: sprawl::style::Dimension::Points(3f32),
+                    cross_end: sprawl::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,17 +33,17 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                 flex_direction: sprawl::style::FlexDirection::Column,
                 size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(0.5f32), ..Default::default() },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+                    main_start: sprawl::style::Dimension::Points(5f32),
+                    main_end: sprawl::style::Dimension::Points(5f32),
+                    cross_start: sprawl::style::Dimension::Points(5f32),
+                    cross_end: sprawl::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.03f32),
-                    end: sprawl::style::Dimension::Percent(0.03f32),
-                    top: sprawl::style::Dimension::Percent(0.03f32),
-                    bottom: sprawl::style::Dimension::Percent(0.03f32),
+                    main_start: sprawl::style::Dimension::Percent(0.03f32),
+                    main_end: sprawl::style::Dimension::Percent(0.03f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.03f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.03f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -62,17 +62,17 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+                    main_start: sprawl::style::Dimension::Points(5f32),
+                    main_end: sprawl::style::Dimension::Points(5f32),
+                    cross_start: sprawl::style::Dimension::Points(5f32),
+                    cross_end: sprawl::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                    main_start: sprawl::style::Dimension::Points(3f32),
+                    main_end: sprawl::style::Dimension::Points(3f32),
+                    cross_start: sprawl::style::Dimension::Points(3f32),
+                    cross_end: sprawl::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -20,10 +20,10 @@ fn percentage_padding_should_calculate_based_only_on_width() {
                 flex_direction: sprawl::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    main_start: sprawl::style::Dimension::Percent(0.1f32),
+                    main_end: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_position_bottom_right.rs
+++ b/tests/generated/percentage_position_bottom_right.rs
@@ -10,8 +10,8 @@ fn percentage_position_bottom_right() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Percent(0.2f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                    main_end: sprawl::style::Dimension::Percent(0.2f32),
+                    cross_end: sprawl::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_position_left_top.rs
+++ b/tests/generated/percentage_position_left_top.rs
@@ -10,8 +10,8 @@ fn percentage_position_left_top() {
                     ..Default::default()
                 },
                 position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.2f32),
+                    main_start: sprawl::style::Dimension::Percent(0.1f32),
+                    cross_start: sprawl::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/tests/generated/percentage_size_based_on_parent_inner_size.rs
@@ -24,10 +24,10 @@ fn percentage_size_based_on_parent_inner_size() {
                     ..Default::default()
                 },
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/relative_position_should_not_nudge_siblings.rs
+++ b/tests/generated/relative_position_should_not_nudge_siblings.rs
@@ -5,7 +5,10 @@ fn relative_position_should_not_nudge_siblings() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(15f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],
@@ -15,7 +18,10 @@ fn relative_position_should_not_nudge_siblings() {
         .new_node(
             sprawl::style::Style {
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+                position: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(15f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[],

--- a/tests/generated/rounding_total_fractial_nested.rs
+++ b/tests/generated/rounding_total_fractial_nested.rs
@@ -8,7 +8,7 @@ fn rounding_total_fractial_nested() {
                 flex_basis: sprawl::style::Dimension::Points(0.3f32),
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(9.9f32), ..Default::default() },
                 position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(13.3f32),
+                    cross_end: sprawl::style::Dimension::Points(13.3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,7 +23,7 @@ fn rounding_total_fractial_nested() {
                 flex_basis: sprawl::style::Dimension::Points(0.3f32),
                 size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(1.1f32), ..Default::default() },
                 position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(13.3f32),
+                    cross_start: sprawl::style::Dimension::Points(13.3f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/size_defined_by_child_with_border.rs
+++ b/tests/generated/size_defined_by_child_with_border.rs
@@ -18,10 +18,10 @@ fn size_defined_by_child_with_border() {
         .new_node(
             sprawl::style::Style {
                 border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/size_defined_by_child_with_padding.rs
+++ b/tests/generated/size_defined_by_child_with_padding.rs
@@ -18,10 +18,10 @@ fn size_defined_by_child_with_padding() {
         .new_node(
             sprawl::style::Style {
                 padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                    main_start: sprawl::style::Dimension::Points(10f32),
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    cross_end: sprawl::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -37,7 +37,10 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
         .new_node(
             sprawl::style::Style {
                 flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    cross_start: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[node010],

--- a/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -37,7 +37,10 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
         .new_node(
             sprawl::style::Style {
                 flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: sprawl::geometry::Rect {
+                    main_end: sprawl::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             &[node010],

--- a/tests/generated/wrapped_column_max_height.rs
+++ b/tests/generated/wrapped_column_max_height.rs
@@ -27,10 +27,10 @@ fn wrapped_column_max_height() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/generated/wrapped_column_max_height_flex.rs
+++ b/tests/generated/wrapped_column_max_height_flex.rs
@@ -33,10 +33,10 @@ fn wrapped_column_max_height_flex() {
                     ..Default::default()
                 },
                 margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                    main_start: sprawl::style::Dimension::Points(20f32),
+                    main_end: sprawl::style::Dimension::Points(20f32),
+                    cross_start: sprawl::style::Dimension::Points(20f32),
+                    cross_end: sprawl::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -102,10 +102,10 @@ mod measure {
                         ..Default::default()
                     },
                     padding: sprawl::geometry::Rect {
-                        start: sprawl::style::Dimension::Points(10.0),
-                        end: sprawl::style::Dimension::Points(10.0),
-                        top: sprawl::style::Dimension::Points(10.0),
-                        bottom: sprawl::style::Dimension::Points(10.0),
+                        main_start: sprawl::style::Dimension::Points(10.0),
+                        main_end: sprawl::style::Dimension::Points(10.0),
+                        cross_start: sprawl::style::Dimension::Points(10.0),
+                        cross_end: sprawl::style::Dimension::Points(10.0),
                     },
                     ..Default::default()
                 },


### PR DESCRIPTION
# Objective

Make `Rect` adhere to flexbox specifications by renaming its fields.

Related to #98 

## Context

Standard defined here
https://www.w3.org/TR/css-flexbox-1/#box-model

![image](https://user-images.githubusercontent.com/13300393/172949732-b8c08a82-a49a-4eed-9e00-f5819b0265df.png)


## Feedback wanted

- Does it make it more difficult to mentally model what is happening, with this change?
- Is it simply a case of users (us) needing to learn the two-axis (main / cross) concept of flexbox?
- This _would_ make it easier to support multiple writing directions and layouts, so most likely we will need this change at some point in the future regardless