### PR TITLE
Add `#[must_use]` to all static methods

### DIFF
--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -268,6 +268,7 @@ impl Forest {
     /// otherwise, subtract the flex container’s margin, border, and padding from the space available to the flex container in that dimension and use that value.
     /// **This might result in an infinite value**.
     #[inline]
+    #[must_use]
     fn determine_available_space(
         node_size: Size<Number>,
         parent_size: Size<Number>,
@@ -1204,6 +1205,7 @@ impl Forest {
     ///
     ///     - Otherwise, use the sum of the flex lines' cross sizes, clamped by the used min and max cross sizes of the flex container.
     #[inline]
+    #[must_use]
     fn determine_container_cross_size(
         flex_lines: &mut [FlexLine],
         node_size: Size<Number>,

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -18,6 +18,7 @@ pub(crate) struct NodeData {
 }
 
 impl NodeData {
+    #[must_use]
     fn new_leaf(style: Style, measure: MeasureFunc) -> Self {
         Self {
             style,
@@ -29,6 +30,7 @@ impl NodeData {
         }
     }
 
+    #[must_use]
     fn new(style: Style) -> Self {
         Self {
             style,
@@ -58,6 +60,7 @@ pub(crate) struct Forest {
 }
 
 impl Forest {
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             nodes: new_vec_with_capacity(capacity),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -109,6 +109,7 @@ pub struct Size<T> {
 }
 
 impl Size<()> {
+    #[must_use]
     pub fn undefined() -> Size<Number> {
         Size { width: Number::Undefined, height: Number::Undefined }
     }
@@ -156,6 +157,7 @@ impl<T> Size<T> {
 }
 
 impl Size<f32> {
+    #[must_use]
     pub fn zero() -> Self {
         Self { width: 0.0, height: 0.0 }
     }
@@ -174,6 +176,7 @@ pub struct Point<T> {
 }
 
 impl Point<f32> {
+    #[must_use]
     pub fn zero() -> Self {
         Self { x: 0.0, y: 0.0 }
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -17,6 +17,7 @@ pub struct Layout {
 }
 
 impl Layout {
+    #[must_use]
     pub(crate) fn new() -> Self {
         Self { order: 0, size: Size::zero(), location: Point::zero() }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -40,6 +40,7 @@ impl Default for Sprawl {
 }
 
 impl Sprawl {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -238,6 +239,7 @@ pub(crate) struct Allocator {
 }
 
 impl Allocator {
+    #[must_use]
     pub const fn new() -> Self {
         Self { new_id: AtomicUsize::new(0) }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -107,6 +107,7 @@ impl MinMax<Number, f32> for f32 {
 }
 
 impl From<f32> for Number {
+    #[must_use]
     fn from(v: f32) -> Self {
         Self::Defined(v)
     }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -18,6 +18,7 @@ mod std {
     pub type ChildrenVec<A> = std::vec::Vec<A>;
     pub type ParentsVec<A> = std::vec::Vec<A>;
 
+    #[must_use]
     pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V>
     where
         K: Eq + std::hash::Hash,
@@ -25,16 +26,19 @@ mod std {
         Map::with_capacity(capacity)
     }
 
+    #[must_use]
     pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
     }
 
     #[inline]
+    #[must_use]
     pub fn round(value: f32) -> f32 {
         value.round()
     }
 
     #[inline]
+    #[must_use]
     pub fn abs(value: f32) -> f32 {
         value.abs()
     }
@@ -50,20 +54,24 @@ mod alloc {
     pub type ChildrenVec<A> = alloc::vec::Vec<A>;
     pub type ParentsVec<A> = alloc::vec::Vec<A>;
 
+    #[must_use]
     pub fn new_map_with_capacity<K, V>(capacity: usize) -> Map<K, V> {
         Map::with_capacity(capacity)
     }
 
+    #[must_use]
     pub fn new_vec_with_capacity<A>(capacity: usize) -> Vec<A> {
         Vec::with_capacity(capacity)
     }
 
     #[inline]
+    #[must_use]
     pub fn round(value: f32) -> f32 {
         num_traits::float::FloatCore::round(value)
     }
 
     #[inline]
+    #[must_use]
     pub fn abs(value: f32) -> f32 {
         num_traits::float::FloatCore::abs(value)
     }
@@ -80,6 +88,7 @@ mod core {
     pub type ChildrenVec<A> = arrayvec::ArrayVec<A, MAX_CHILD_COUNT>;
     pub type ParentsVec<A> = arrayvec::ArrayVec<A, MAX_PARENTS_COUNT>;
 
+    #[must_use]
     pub fn new_map_with_capacity<K, V>(_capacity: usize) -> Map<K, V>
     where
         K: Eq + ::hash32::Hash,
@@ -87,16 +96,19 @@ mod core {
         Map::new()
     }
 
+    #[must_use]
     pub fn new_vec_with_capacity<A, const CAP: usize>(_capacity: usize) -> arrayvec::ArrayVec<A, CAP> {
         arrayvec::ArrayVec::new()
     }
 
     #[inline]
+    #[must_use]
     pub fn round(value: f32) -> f32 {
         num_traits::float::FloatCore::round(value)
     }
 
     #[inline]
+    #[must_use]
     pub fn abs(value: f32) -> f32 {
         num_traits::float::FloatCore::abs(value)
     }


### PR DESCRIPTION
# Objective

Fixes #103 

## Context

I've just naively added `#[must_use]` and all static methods I could find, which also include constructors. I don't know if that is the correct approach, so please let me know.
