### PR TITLE
Rename sprawl to taffy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,13 +6,13 @@ labels: bug
 assignees: ''
 ---
 
-## `sprawl` version
+## `taffy` version
 
 The release number or commit hash of the version you're using.
 
 ## Platform
 
-What platform are you using `sprawl` on? e.g. Rust, Andriod, IOS, JavaScript/TypeScript
+What platform are you using `taffy` on? e.g. Rust, Andriod, IOS, JavaScript/TypeScript
 
 ## What you did
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ New contributions are extremely welcome!
 
 The basic process is simple:
 
-1. Pick an [issue](https://github.com/DioxusLabs/sprawl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), or [file a new one](https://github.com/DioxusLabs/sprawl/issues/new).
+1. Pick an [issue](https://github.com/DioxusLabs/taffy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), or [file a new one](https://github.com/DioxusLabs/taffy/issues/new).
 2. Comment in the issue that you plan to tackle it, and the team will assign the task to you.
 3. Submit a PR.
 4. Respond to feedback from reviewers and make sure CI passes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sprawl"
+name = "taffy"
 version = "0.1.0"
 authors = [
     "Alice Cecile <alice.i.cecile@gmail.com>",
@@ -8,7 +8,7 @@ authors = [
 edition = "2021"
 include = ["src/**/*", "Cargo.toml"]
 description = "A flexible UI layout library"
-repository = "https://github.com/DioxusLabs/sprawl"
+repository = "https://github.com/DioxusLabs/taffy"
 keywords = ["cross-platform", "layout", "flexbox"]
 categories = ["gui"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# sprawl
+# taffy
 
-[![GitHub CI](https://github.com/DioxusLabs/sprawl/actions/workflows/ci.yml/badge.svg)](https://github.com/DioxusLabs/sprawl/actions/workflows/ci.yml)
-[![crates.io](https://img.shields.io/crates/v/sprawl.svg)](https://crates.io/crates/sprawl)
+[![GitHub CI](https://github.com/DioxusLabs/taffy/actions/workflows/ci.yml/badge.svg)](https://github.com/DioxusLabs/taffy/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/taffy.svg)](https://crates.io/crates/taffy)
 
-`sprawl` is a flexible, high-performance, cross-platform UI layout library written in [Rust](https://www.rust-lang.org).
+`taffy` is a flexible, high-performance, cross-platform UI layout library written in [Rust](https://www.rust-lang.org).
 
-Currently, we only support a [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) layout algorithm, but support for other paradigms [is planned](https://github.com/DioxusLabs/sprawl/issues/28).
+Currently, we only support a [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) layout algorithm, but support for other paradigms [is planned](https://github.com/DioxusLabs/taffy/issues/28).
 
 This crate is a collaborative, cross-team project, and is designed to be used as a dependency for other UI and GUI libraries.
 Right now, it powers:
@@ -13,6 +13,6 @@ Right now, it powers:
 - [Dioxus](https://dioxuslabs.com/): a React-like library for building fast, portable, and beautiful user interfaces with Rust
 - [Bevy](https://bevyengine.org/): an ergonomic, ECS-first Rust game engine
 
-[Contributions welcome](https://github.com/DioxusLabs/sprawl/blob/main/CONTRIBUTING.md):
-if you'd like to use, improve or build `sprawl`, feel free to join the conversation, open an [issue](https://github.com/DioxusLabs/sprawl/issues) or submit a [PR](https://github.com/DioxusLabs/sprawl/pulls).
-If you have questions about how to use `sprawl`, open a [discussion](https://github.com/DioxusLabs/sprawl/discussions) so we can answer your questions in a way that others can find.
+[Contributions welcome](https://github.com/DioxusLabs/taffy/blob/main/CONTRIBUTING.md):
+if you'd like to use, improve or build `taffy`, feel free to join the conversation, open an [issue](https://github.com/DioxusLabs/taffy/issues) or submit a [PR](https://github.com/DioxusLabs/taffy/pulls).
+If you have questions about how to use `taffy`, open a [discussion](https://github.com/DioxusLabs/taffy/discussions) so we can answer your questions in a way that others can find.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,9 +5,9 @@
 ### 0.1.0 Changed
 
 - the `order` field of `Layout` is now public, and describes the relative z-ordering of nodes
-- renamed crate from `stretch2` to `sprawl`
+- renamed crate from `stretch2` to `taffy`
 - updated to the latest version of all dependencies to reduce upstream pain caused by duplicate dependencies
-- renamed `stretch::node::Strech` -> `sprawl::node::Sprawl`
+- renamed `stretch::node::Strech` -> `taffy::node::Taffy`
 
 ### 0.1.0 Fixed
 
@@ -18,14 +18,14 @@
 - removed Javascript / Kotlin / Swift bindings
   - the maintainer team lacks expertise to keep these working
   - more serious refactors are planned, and this will be challenging to keep working through that process
-  - if you are interested in helping us maintain bindings to other languages, [get in touch](https://github.com/DioxusLabs/sprawl/discussions)!
+  - if you are interested in helping us maintain bindings to other languages, [get in touch](https://github.com/DioxusLabs/taffy/discussions)!
 - the `serde_camel_case` and `serde_kebab_case` features have been removed: they were poorly motivated and were not correctly additive (if both were enabled compilation would fail)
 - removed the `Direction` and `Overflow` structs, and the corresponding `direction` and `overflow` fields from `Style`
   - these had no effect in the current code base and were actively misleading
 
 ## stretch2 0.4.3
 
-This is the final release of `stretch`: migrate to the crate named `sprawl` for future fixes and features!
+This is the final release of `stretch`: migrate to the crate named `taffy` for future fixes and features!
 
 These notes describe the differences between this release and `stretch` 0.3.2, the abandoned crate from which this library was forked.
 

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -1,49 +1,24 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn build_deep_hierarchy(sprawl: &mut sprawl::node::Sprawl) -> sprawl::node::Node {
-    let node111 = sprawl
+fn build_deep_hierarchy(taffy: &mut taffy::node::Taffy) -> taffy::node::Node {
+    let node111 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
                 },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node112 = sprawl
+    let node112 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-
-    let node121 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node122 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
                 },
                 ..Default::default()
             },
@@ -51,53 +26,24 @@ fn build_deep_hierarchy(sprawl: &mut sprawl::node::Sprawl) -> sprawl::node::Node
         )
         .unwrap();
 
-    let node11 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node111, node112]).unwrap();
-    let node12 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node121, node122]).unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node11, node12]).unwrap();
-
-    let node211 = sprawl
+    let node121 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
                 },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node212 = sprawl
+    let node122 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-
-    let node221 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node222 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10.0),
-                    height: sprawl::style::Dimension::Points(10.0),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
                 },
                 ..Default::default()
             },
@@ -105,40 +51,94 @@ fn build_deep_hierarchy(sprawl: &mut sprawl::node::Sprawl) -> sprawl::node::Node
         )
         .unwrap();
 
-    let node21 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node211, node212]).unwrap();
-    let node22 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node221, node222]).unwrap();
+    let node11 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node111, node112]).unwrap();
+    let node12 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node121, node122]).unwrap();
+    let node1 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node11, node12]).unwrap();
 
-    let node2 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node21, node22]).unwrap();
+    let node211 = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node212 = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
 
-    sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node1, node2]).unwrap()
+    let node221 = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node222 = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10.0),
+                    height: taffy::style::Dimension::Points(10.0),
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+
+    let node21 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node211, node212]).unwrap();
+    let node22 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node221, node222]).unwrap();
+
+    let node2 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node21, node22]).unwrap();
+
+    taffy.new_node(taffy::style::Style { ..Default::default() }, &[node1, node2]).unwrap()
 }
 
-fn sprawl_benchmarks(c: &mut Criterion) {
+fn taffy_benchmarks(c: &mut Criterion) {
     c.bench_function("deep hierarchy - build", |b| {
         b.iter(|| {
-            let mut sprawl = sprawl::node::Sprawl::new();
-            build_deep_hierarchy(&mut sprawl);
+            let mut taffy = taffy::node::Taffy::new();
+            build_deep_hierarchy(&mut taffy);
         })
     });
 
     c.bench_function("deep hierarchy - single", |b| {
         b.iter(|| {
-            let mut sprawl = sprawl::node::Sprawl::new();
-            let root = build_deep_hierarchy(&mut sprawl);
-            sprawl.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
+            let mut taffy = taffy::node::Taffy::new();
+            let root = build_deep_hierarchy(&mut taffy);
+            taffy.compute_layout(root, taffy::geometry::Size::undefined()).unwrap()
         })
     });
 
     c.bench_function("deep hierarchy - relayout", |b| {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let root = build_deep_hierarchy(&mut sprawl);
+        let mut taffy = taffy::node::Taffy::new();
+        let root = build_deep_hierarchy(&mut taffy);
 
         b.iter(|| {
-            sprawl.mark_dirty(root).unwrap();
-            sprawl.compute_layout(root, sprawl::geometry::Size::undefined()).unwrap()
+            taffy.mark_dirty(root).unwrap();
+            taffy.compute_layout(root, taffy::geometry::Size::undefined()).unwrap()
         })
     });
 }
 
-criterion_group!(benches, sprawl_benchmarks);
+criterion_group!(benches, taffy_benchmarks);
 criterion_main!(benches);

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,14 +18,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -1,31 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    ..Default::default()
-                },
+                position: taffy::geometry::Rect { start: taffy::style::Dimension::Points(5f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -1,28 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(5f32), ..Default::default() },
+                position: taffy::geometry::Rect { end: taffy::style::Dimension::Points(5f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -1,28 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/benches/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexEnd,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_center.rs
+++ b/benches/generated/absolute_layout_align_items_center.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/benches/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                align_self: sprawl::style::AlignSelf::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                align_self: taffy::style::AlignSelf::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_child_order.rs
+++ b/benches/generated/absolute_layout_child_order.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,14 +40,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/benches/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_justify_content_center.rs
+++ b/benches/generated/absolute_layout_justify_content_center.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_no_size.rs
+++ b/benches/generated/absolute_layout_no_size.rs
@@ -1,17 +1,17 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },
+            taffy::style::Style { position_type: taffy::style::PositionType::Absolute, ..Default::default() },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,5 +19,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/benches/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -1,16 +1,31 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.5f32),
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Percent(0.5f32), ..Default::default() },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node1 = taffy
+        .new_node(
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
+                position: taffy::geometry::Rect {
+                    bottom: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,17 +33,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
-                position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Percent(0.5f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Percent(0.1f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,27 +48,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -64,5 +61,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_start_top_end_bottom.rs
@@ -1,14 +1,14 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,12 +16,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_end_bottom.rs
@@ -1,17 +1,17 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,12 +19,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_start_top.rs
+++ b/benches/generated/absolute_layout_width_height_start_top.rs
@@ -1,17 +1,17 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,12 +19,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/benches/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -1,19 +1,19 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -21,12 +21,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/absolute_layout_within_border.rs
+++ b/benches/generated/absolute_layout_within_border.rs
@@ -1,17 +1,17 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(0f32),
+                    top: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,18 +19,18 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Points(0f32),
+                    bottom: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,25 +38,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(0f32),
+                    top: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -64,25 +64,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Points(0f32),
+                    bottom: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -90,26 +90,26 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -117,5 +117,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_baseline.rs
+++ b/benches/generated/align_baseline.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,13 +26,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_baseline_child_multiline.rs
+++ b/benches/generated/align_baseline_child_multiline.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(60f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node11 = sprawl
+    let node11 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node12 = sprawl
+    let node12 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node13 = sprawl
+    let node13 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,25 +65,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10, node11, node12, node13],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Baseline,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Baseline,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_baseline_nested_child.rs
+++ b/benches/generated/align_baseline_nested_child.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,13 +26,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,13 +40,13 @@ pub fn compute() {
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -54,5 +54,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_center_should_size_based_on_content.rs
+++ b/benches/generated/align_center_should_size_based_on_content.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
                 ..Default::default()
@@ -27,13 +27,13 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_flex_start_with_shrinking_children.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children.rs
@@ -1,23 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
+    let mut taffy = taffy::Taffy::new();
+    let node000 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
-        .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexStart, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexStart, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/benches/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -1,23 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
+    let mut taffy = taffy::Taffy::new();
+    let node000 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
-        .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexStart, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexStart, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_flex_start_with_stretching_children.rs
+++ b/benches/generated/align_flex_start_with_stretching_children.rs
@@ -1,18 +1,17 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
+    let mut taffy = taffy::Taffy::new();
+    let node000 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
-        .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,5 +19,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_center.rs
+++ b/benches/generated/align_items_center.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,20 +18,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::Center, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::Center, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(70f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(70f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,20 +13,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::Center, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::Center, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_center_with_child_margin.rs
+++ b/benches/generated/align_items_center_with_child_margin.rs
@@ -1,26 +1,26 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_center_with_child_top.rs
+++ b/benches/generated/align_items_center_with_child_top.rs
@@ -1,26 +1,26 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_flex_end.rs
+++ b/benches/generated/align_items_flex_end.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,20 +18,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexEnd, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexEnd, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/benches/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(70f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(70f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,20 +13,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexEnd, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexEnd, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_flex_start.rs
+++ b/benches/generated/align_items_flex_start.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_min_max.rs
+++ b/benches/generated/align_items_min_max.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(60f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,18 +13,18 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_items_stretch.rs
+++ b/benches/generated/align_items_stretch.rs
@@ -1,20 +1,20 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,5 +22,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_self_baseline.rs
+++ b/benches/generated/align_self_baseline.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,12 +41,12 @@ pub fn compute() {
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -54,5 +54,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_self_center.rs
+++ b/benches/generated/align_self_center.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_self_flex_end.rs
+++ b/benches/generated/align_self_flex_end.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_self_flex_end_override_flex_start.rs
+++ b/benches/generated/align_self_flex_end_override_flex_start.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_self_flex_start.rs
+++ b/benches/generated/align_self_flex_start.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/align_strech_should_size_based_on_parent.rs
+++ b/benches/generated/align_strech_should_size_based_on_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
                 ..Default::default()
@@ -27,12 +27,12 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/border_center_child.rs
+++ b/benches/generated/border_center_child.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,19 +13,19 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                border: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/border_flex_child.rs
+++ b/benches/generated/border_flex_child.rs
@@ -1,28 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/border_no_child.rs
+++ b/benches/generated/border_no_child.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,5 +15,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/border_stretch_child.rs
+++ b/benches/generated/border_stretch_child.rs
@@ -1,27 +1,27 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/child_min_max_width_flexing.rs
+++ b/benches/generated/child_min_max_width_flexing.rs
@@ -1,41 +1,35 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(0f32),
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(120f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(120f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,5 +37,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/container_with_unsized_child.rs
+++ b/benches/generated/container_with_unsized_child.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,5 +14,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/display_none.rs
+++ b/benches/generated/display_none.rs
@@ -1,18 +1,18 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style { display: sprawl::style::Display::None, flex_grow: 1f32, ..Default::default() },
+            taffy::style::Style { display: taffy::style::Display::None, flex_grow: 1f32, ..Default::default() },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,5 +20,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/display_none_fixed_size.rs
+++ b/benches/generated/display_none_fixed_size.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                display: taffy::style::Display::None,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/display_none_with_child.rs
+++ b/benches/generated/display_none_with_child.rs
@@ -1,58 +1,58 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                display: taffy::style::Display::None,
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -60,5 +60,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/display_none_with_margin.rs
+++ b/benches/generated/display_none_with_margin.rs
@@ -1,19 +1,19 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                display: taffy::style::Display::None,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -21,13 +21,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/display_none_with_position.rs
+++ b/benches/generated/display_none_with_position.rs
@@ -1,23 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
+            taffy::style::Style {
+                display: taffy::style::Display::None,
                 flex_grow: 1f32,
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/benches/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(0f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(0f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,14 +30,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_flex_grow_column.rs
+++ b/benches/generated/flex_basis_flex_grow_column.rs
@@ -1,23 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_flex_grow_row.rs
+++ b/benches/generated/flex_basis_flex_grow_row.rs
@@ -1,22 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_flex_shrink_column.rs
+++ b/benches/generated/flex_basis_flex_shrink_column.rs
@@ -1,24 +1,21 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style { flex_basis: taffy::style::Dimension::Points(100f32), ..Default::default() },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-            &[],
-        )
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(50f32), ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,5 +23,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_flex_shrink_row.rs
+++ b/benches/generated/flex_basis_flex_shrink_row.rs
@@ -1,23 +1,20 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style { flex_basis: taffy::style::Dimension::Points(100f32), ..Default::default() },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-            &[],
-        )
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(50f32), ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,5 +22,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_larger_than_content_column.rs
+++ b/benches/generated/flex_basis_larger_than_content_column.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,25 +13,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_larger_than_content_row.rs
+++ b/benches/generated/flex_basis_larger_than_content_row.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,24 +13,24 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_overrides_main_size.rs
+++ b/benches/generated/flex_basis_overrides_main_size.rs
@@ -1,42 +1,42 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(60f32),
+                flex_basis: taffy::style::Dimension::Points(60f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_content_column.rs
+++ b/benches/generated/flex_basis_smaller_than_content_column.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,25 +13,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_content_row.rs
+++ b/benches/generated/flex_basis_smaller_than_content_row.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,24 +13,24 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,15 +14,15 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/benches/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,17 +37,17 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_unconstraint_column.rs
+++ b/benches/generated/flex_basis_unconstraint_column.rs
@@ -1,20 +1,20 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_basis_unconstraint_row.rs
+++ b/benches/generated/flex_basis_unconstraint_row.rs
@@ -1,15 +1,15 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_column.rs
+++ b/benches/generated/flex_direction_column.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_column_no_height.rs
+++ b/benches/generated/flex_direction_column_no_height.rs
@@ -1,41 +1,41 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_column_reverse.rs
+++ b/benches/generated/flex_direction_column_reverse.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::ColumnReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::ColumnReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_row.rs
+++ b/benches/generated/flex_direction_row.rs
@@ -1,38 +1,38 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_row_no_width.rs
+++ b/benches/generated/flex_direction_row_no_width.rs
@@ -1,40 +1,40 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_direction_row_reverse.rs
+++ b/benches/generated/flex_direction_row_reverse.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::RowReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::RowReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_child.rs
+++ b/benches/generated/flex_grow_child.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(0f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/benches/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -1,49 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(0f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(120f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(120f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_height_maximized.rs
+++ b/benches/generated/flex_grow_height_maximized.rs
@@ -1,35 +1,35 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Points(200f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,13 +37,13 @@ pub fn compute() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -51,5 +51,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_in_at_most_container.rs
+++ b/benches/generated/flex_grow_in_at_most_container.rs
@@ -1,23 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_less_than_factor_one.rs
+++ b/benches/generated/flex_grow_less_than_factor_one.rs
@@ -1,28 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0.2f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Points(40f32),
+                flex_basis: taffy::style::Dimension::Points(40f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, &[])
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
-    let node2 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, &[])
+    let node2 = taffy
+        .new_node(taffy::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_root_minimized.rs
+++ b/benches/generated/flex_grow_root_minimized.rs
@@ -1,35 +1,35 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Points(200f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,17 +37,17 @@ pub fn compute() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_shrink_at_most.rs
+++ b/benches/generated/flex_grow_shrink_at_most.rs
@@ -1,15 +1,14 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
-        .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -17,5 +16,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_to_min.rs
+++ b/benches/generated/flex_grow_to_min.rs
@@ -1,28 +1,27 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
-        .unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +29,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_max_column.rs
@@ -1,31 +1,31 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(100f32),
+                flex_basis: taffy::style::Dimension::Points(100f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_row.rs
+++ b/benches/generated/flex_grow_within_constrained_max_row.rs
@@ -1,30 +1,30 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(100f32),
+                flex_basis: taffy::style::Dimension::Points(100f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,15 +32,15 @@ pub fn compute() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_max_width.rs
+++ b/benches/generated/flex_grow_within_constrained_max_width.rs
@@ -1,20 +1,20 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(300f32),
+            taffy::style::Style {
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(300f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,13 +22,13 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_column.rs
@@ -1,21 +1,21 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/benches/generated/flex_grow_within_constrained_min_max_column.rs
@@ -1,20 +1,20 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,5 +22,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_constrained_min_row.rs
+++ b/benches/generated/flex_grow_within_constrained_min_row.rs
@@ -1,21 +1,21 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_grow_within_max_width.rs
+++ b/benches/generated/flex_grow_within_max_width.rs
@@ -1,20 +1,20 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,13 +22,13 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,5 +36,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_root_ignored.rs
+++ b/benches/generated/flex_root_ignored.rs
@@ -1,35 +1,35 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Points(200f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,5 +37,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/benches/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -1,26 +1,26 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/benches/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,12 +30,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_shrink_flex_grow_row.rs
+++ b/benches/generated/flex_shrink_flex_grow_row.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,12 +30,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,5 +43,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_shrink_to_zero.rs
+++ b/benches/generated/flex_shrink_to_zero.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,14 +42,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(75f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(75f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/benches/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -1,30 +1,30 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/benches/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -1,42 +1,36 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(55f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(55f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(55f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(55f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/flex_wrap_wrap_to_child_height.rs
+++ b/benches/generated/flex_wrap_wrap_to_child_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,32 +13,32 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::FlexStart,
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::FlexStart,
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,11 +46,11 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_center.rs
+++ b/benches/generated/justify_content_column_center.rs
@@ -1,40 +1,40 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_flex_end.rs
+++ b/benches/generated/justify_content_column_flex_end.rs
@@ -1,40 +1,40 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_flex_start.rs
+++ b/benches/generated/justify_content_column_flex_start.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -1,29 +1,26 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/benches/generated/justify_content_column_min_height_and_margin_top.rs
@@ -1,26 +1,26 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_space_around.rs
+++ b/benches/generated/justify_content_column_space_around.rs
@@ -1,40 +1,40 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::SpaceAround,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::SpaceAround,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_space_between.rs
+++ b/benches/generated/justify_content_column_space_between.rs
@@ -1,40 +1,40 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::SpaceBetween,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::SpaceBetween,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_column_space_evenly.rs
+++ b/benches/generated/justify_content_column_space_evenly.rs
@@ -1,40 +1,40 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::SpaceEvenly,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::SpaceEvenly,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_min_max.rs
+++ b/benches/generated/justify_content_min_max.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(60f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,18 +13,18 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(300f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(300f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,17 +13,17 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(100f32),
+                    end: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,14 +31,14 @@ pub fn compute() {
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(1000f32),
-                    height: sprawl::style::Dimension::Points(1584f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(1000f32),
+                    height: taffy::style::Dimension::Points(1584f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,5 +46,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/benches/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(199f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(199f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,17 +13,17 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(100f32),
+                    end: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,14 +31,14 @@ pub fn compute() {
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(1080f32),
-                    height: sprawl::style::Dimension::Points(1584f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(1080f32),
+                    height: taffy::style::Dimension::Points(1584f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,5 +46,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_overflow_min_max.rs
+++ b/benches/generated/justify_content_overflow_min_max.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(110f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(110f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -60,5 +60,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_center.rs
+++ b/benches/generated/justify_content_row_center.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_flex_end.rs
+++ b/benches/generated/justify_content_row_flex_end.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_flex_start.rs
+++ b/benches/generated/justify_content_row_flex_start.rs
@@ -1,38 +1,38 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_max_width_and_margin.rs
+++ b/benches/generated/justify_content_row_max_width_and_margin.rs
@@ -1,35 +1,29 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    ..Default::default()
-                },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(80f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_min_width_and_margin.rs
+++ b/benches/generated/justify_content_row_min_width_and_margin.rs
@@ -1,31 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_space_around.rs
+++ b/benches/generated/justify_content_row_space_around.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::SpaceAround,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::SpaceAround,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_space_between.rs
+++ b/benches/generated/justify_content_row_space_between.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::SpaceBetween,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::SpaceBetween,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/justify_content_row_space_evenly.rs
+++ b/benches/generated/justify_content_row_space_evenly.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::SpaceEvenly,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::SpaceEvenly,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_and_flex_column.rs
+++ b/benches/generated/margin_and_flex_column.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_and_flex_row.rs
+++ b/benches/generated/margin_and_flex_row.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_and_stretch_column.rs
+++ b/benches/generated/margin_and_stretch_column.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_and_stretch_row.rs
+++ b/benches/generated/margin_and_stretch_row.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_bottom.rs
+++ b/benches/generated/margin_auto_bottom.rs
@@ -1,25 +1,25 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { bottom: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_bottom_and_top.rs
+++ b/benches/generated/margin_auto_bottom_and_top.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Auto,
+                    bottom: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +18,26 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/benches/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Auto,
+                    bottom: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +18,26 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left.rs
+++ b/benches/generated/margin_auto_left.rs
@@ -1,25 +1,25 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right.rs
+++ b/benches/generated/margin_auto_left_and_right.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,12 +18,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_column.rs
+++ b/benches/generated/margin_auto_left_and_right_column.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +18,26 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/benches/generated/margin_auto_left_and_right_column_and_center.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +18,26 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_and_right_strech.rs
+++ b/benches/generated/margin_auto_left_and_right_strech.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,12 +18,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -1,26 +1,26 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,13 +18,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,13 +18,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_left_stretching_child.rs
+++ b/benches/generated/margin_auto_left_stretching_child.rs
@@ -1,23 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,13 +25,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_mutiple_children_column.rs
+++ b/benches/generated/margin_auto_mutiple_children_column.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,14 +41,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -56,5 +56,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_mutiple_children_row.rs
+++ b/benches/generated/margin_auto_mutiple_children_row.rs
@@ -1,39 +1,39 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,13 +41,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -55,5 +55,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_right.rs
+++ b/benches/generated/margin_auto_right.rs
@@ -1,25 +1,25 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_top.rs
+++ b/benches/generated/margin_auto_top.rs
@@ -1,25 +1,25 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_top_and_bottom_strech.rs
+++ b/benches/generated/margin_auto_top_and_bottom_strech.rs
@@ -1,29 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Auto,
+                    bottom: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +18,26 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_auto_top_stretching_child.rs
+++ b/benches/generated/margin_auto_top_stretching_child.rs
@@ -1,23 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,13 +25,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_bottom.rs
+++ b/benches/generated/margin_bottom.rs
@@ -1,26 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +25,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/benches/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Auto,
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,13 +18,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,5 +32,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_left.rs
+++ b/benches/generated/margin_left.rs
@@ -1,21 +1,21 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_right.rs
+++ b/benches/generated/margin_right.rs
@@ -1,22 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_should_not_be_part_of_max_height.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_height.rs
@@ -1,29 +1,29 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(250f32),
-                    height: sprawl::style::Dimension::Points(250f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(250f32),
+                    height: taffy::style::Dimension::Points(250f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_should_not_be_part_of_max_width.rs
+++ b/benches/generated/margin_should_not_be_part_of_max_width.rs
@@ -1,29 +1,29 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(250f32),
-                    height: sprawl::style::Dimension::Points(250f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(250f32),
+                    height: taffy::style::Dimension::Points(250f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_top.rs
+++ b/benches/generated/margin_top.rs
@@ -1,22 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_with_sibling_column.rs
+++ b/benches/generated/margin_with_sibling_column.rs
@@ -1,26 +1,23 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +25,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/margin_with_sibling_row.rs
+++ b/benches/generated/margin_with_sibling_row.rs
@@ -1,22 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_height.rs
+++ b/benches/generated/max_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_height_overrides_height.rs
+++ b/benches/generated/max_height_overrides_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,6 +13,6 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_height_overrides_height_on_root.rs
+++ b/benches/generated/max_height_overrides_height_on_root.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_width.rs
+++ b/benches/generated/max_width.rs
@@ -1,25 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +24,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_width_overrides_width.rs
+++ b/benches/generated/max_width_overrides_width.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,6 +13,6 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/max_width_overrides_width_on_root.rs
+++ b/benches/generated/max_width_overrides_width_on_root.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_height.rs
+++ b/benches/generated/min_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(60f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,14 +13,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_height_overrides_height.rs
+++ b/benches/generated/min_height_overrides_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,6 +13,6 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_height_overrides_height_on_root.rs
+++ b/benches/generated/min_height_overrides_height_on_root.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_max_percent_no_width_height.rs
+++ b/benches/generated/min_max_percent_no_width_height.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.1f32),
-                    height: sprawl::style::Dimension::Percent(0.1f32),
+            taffy::style::Style {
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.1f32),
+                    height: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.1f32),
-                    height: sprawl::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.1f32),
+                    height: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,14 +18,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_width.rs
+++ b/benches/generated/min_width.rs
@@ -1,25 +1,22 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    ..Default::default()
-                },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +24,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_width_overrides_width.rs
+++ b/benches/generated/min_width_overrides_width.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,6 +13,6 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/min_width_overrides_width_on_root.rs
+++ b/benches/generated/min_width_overrides_width_on_root.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,5 +13,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/nested_overflowing_child.rs
+++ b/benches/generated/nested_overflowing_child.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,13 +13,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,5 +27,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/benches/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,5 +39,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/overflow_cross_axis.rs
+++ b/benches/generated/overflow_cross_axis.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/overflow_main_axis.rs
+++ b/benches/generated/overflow_main_axis.rs
@@ -1,21 +1,21 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,5 +23,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/padding_align_end_child.rs
+++ b/benches/generated/padding_align_end_child.rs
@@ -1,18 +1,18 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,14 +20,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexEnd,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/padding_center_child.rs
+++ b/benches/generated/padding_center_child.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,21 +13,21 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/padding_flex_child.rs
+++ b/benches/generated/padding_flex_child.rs
@@ -1,28 +1,28 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,5 +30,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/padding_no_child.rs
+++ b/benches/generated/padding_no_child.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,5 +15,5 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/padding_stretch_child.rs
+++ b/benches/generated/padding_stretch_child.rs
@@ -1,27 +1,27 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,5 +29,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/benches/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,21 +13,21 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,5 +35,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percent_absolute_position.rs
+++ b/benches/generated/percent_absolute_position.rs
@@ -1,34 +1,34 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(1f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.5f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,13 +36,13 @@ pub fn compute() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -50,5 +50,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percent_within_flex_grow.rs
+++ b/benches/generated/percent_within_flex_grow.rs
@@ -1,48 +1,48 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(350f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(350f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -50,5 +50,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_absolute_position.rs
+++ b/benches/generated/percentage_absolute_position.rs
@@ -1,17 +1,17 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.3f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.3f32),
+                    top: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,13 +19,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_container_in_wrapping_container.rs
+++ b/benches/generated/percentage_container_in_wrapping_container.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node001 = sprawl
+    let node001 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,31 +26,31 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[node000, node001],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -58,5 +58,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis.rs
+++ b/benches/generated/percentage_flex_basis.rs
@@ -1,31 +1,31 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.25f32),
+                flex_basis: taffy::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,5 +33,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross.rs
+++ b/benches/generated/percentage_flex_basis_cross.rs
@@ -1,32 +1,32 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.25f32),
+                flex_basis: taffy::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_max_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_height.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_max_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_max_width.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_min_height.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.6f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 2f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,13 +26,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,5 +40,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_cross_min_width.rs
+++ b/benches/generated/percentage_flex_basis_cross_min_width.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,5 +42,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_max_height.rs
+++ b/benches/generated/percentage_flex_basis_main_max_height.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,12 +28,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_max_width.rs
+++ b/benches/generated/percentage_flex_basis_main_max_width.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,12 +28,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_flex_basis_main_min_width.rs
+++ b/benches/generated/percentage_flex_basis_main_min_width.rs
@@ -1,12 +1,12 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,12 +28,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,5 +41,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,16 +13,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.1f32),
+                    end: taffy::style::Dimension::Percent(0.1f32),
+                    top: taffy::style::Dimension::Percent(0.1f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/benches/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -1,24 +1,21 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.45f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.45f32), ..Default::default() },
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.05f32),
+                    end: taffy::style::Dimension::Percent(0.05f32),
+                    top: taffy::style::Dimension::Percent(0.05f32),
+                    bottom: taffy::style::Dimension::Percent(0.05f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.05f32),
-                    end: sprawl::style::Dimension::Percent(0.05f32),
-                    top: sprawl::style::Dimension::Percent(0.05f32),
-                    bottom: sprawl::style::Dimension::Percent(0.05f32),
-                    ..Default::default()
-                },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(3f32),
+                    end: taffy::style::Dimension::Points(3f32),
+                    top: taffy::style::Dimension::Points(3f32),
+                    bottom: taffy::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,23 +23,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(0.5f32), ..Default::default() },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.5f32), ..Default::default() },
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(5f32),
+                    end: taffy::style::Dimension::Points(5f32),
+                    top: taffy::style::Dimension::Points(5f32),
+                    bottom: taffy::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.03f32),
-                    end: sprawl::style::Dimension::Percent(0.03f32),
-                    top: sprawl::style::Dimension::Percent(0.03f32),
-                    bottom: sprawl::style::Dimension::Percent(0.03f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.03f32),
+                    end: taffy::style::Dimension::Percent(0.03f32),
+                    top: taffy::style::Dimension::Percent(0.03f32),
+                    bottom: taffy::style::Dimension::Percent(0.03f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -50,28 +47,28 @@ pub fn compute() {
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(5f32),
+                    end: taffy::style::Dimension::Points(5f32),
+                    top: taffy::style::Dimension::Points(5f32),
+                    bottom: taffy::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(3f32),
+                    end: taffy::style::Dimension::Points(3f32),
+                    top: taffy::style::Dimension::Points(3f32),
+                    bottom: taffy::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -79,13 +76,13 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -93,13 +90,13 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -107,5 +104,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/benches/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,16 +13,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.1f32),
+                    end: taffy::style::Dimension::Percent(0.1f32),
+                    top: taffy::style::Dimension::Percent(0.1f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ pub fn compute() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,5 +44,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_position_bottom_right.rs
+++ b/benches/generated/percentage_position_bottom_right.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.55f32),
-                    height: sprawl::style::Dimension::Percent(0.15f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.55f32),
+                    height: taffy::style::Dimension::Percent(0.15f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Percent(0.2f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Percent(0.2f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,12 +18,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_position_left_top.rs
+++ b/benches/generated/percentage_position_left_top.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.45f32),
-                    height: sprawl::style::Dimension::Percent(0.55f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.45f32),
+                    height: taffy::style::Dimension::Percent(0.55f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.2f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.1f32),
+                    top: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,12 +18,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(400f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,5 +31,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/benches/generated/percentage_size_based_on_parent_inner_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.5f32),
-                    height: sprawl::style::Dimension::Percent(0.5f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.5f32),
+                    height: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,20 +13,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_size_of_flex_basis.rs
+++ b/benches/generated/percentage_size_of_flex_basis.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(1f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,20 +13,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style { flex_basis: taffy::style::Dimension::Points(50f32), ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_width_height.rs
+++ b/benches/generated/percentage_width_height.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.3f32),
-                    height: sprawl::style::Dimension::Percent(0.3f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.3f32),
+                    height: taffy::style::Dimension::Percent(0.3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,5 +26,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/percentage_width_height_undefined_parent_size.rs
+++ b/benches/generated/percentage_width_height_undefined_parent_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.5f32),
-                    height: sprawl::style::Dimension::Percent(0.5f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.5f32),
+                    height: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,11 +13,11 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/relative_position_should_not_nudge_siblings.rs
+++ b/benches/generated/relative_position_should_not_nudge_siblings.rs
@@ -1,32 +1,32 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(15f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(15f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,5 +34,5 @@ pub fn compute() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -1,16 +1,16 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node2 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node3 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node4 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node3 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node4 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(113f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(113f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,5 +18,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/benches/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -1,14 +1,14 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node2 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,5 +16,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/benches/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -1,33 +1,27 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(100f32),
+                flex_basis: taffy::style::Dimension::Points(100f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(25f32), ..Default::default() },
-            &[],
-        )
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(25f32), ..Default::default() }, &[])
         .unwrap();
-    let node2 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(25f32), ..Default::default() },
-            &[],
-        )
+    let node2 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(25f32), ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(101f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(101f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,5 +29,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/benches/generated/rounding_flex_basis_overrides_main_size.rs
@@ -1,43 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_1.rs
+++ b/benches/generated/rounding_fractial_input_1.rs
@@ -1,43 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_2.rs
+++ b/benches/generated/rounding_fractial_input_2.rs
@@ -1,43 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.6f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_3.rs
+++ b/benches/generated/rounding_fractial_input_3.rs
@@ -1,43 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_fractial_input_4.rs
+++ b/benches/generated/rounding_fractial_input_4.rs
@@ -1,43 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_total_fractial.rs
+++ b/benches/generated/rounding_total_fractial.rs
@@ -1,49 +1,43 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0.7f32,
-                flex_basis: sprawl::style::Dimension::Points(50.3f32),
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(20.3f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(50.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20.3f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.6f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.1f32,
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(10.7f32),
-                    ..Default::default()
-                },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10.7f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(87.4f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(87.4f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -51,5 +45,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/rounding_total_fractial_nested.rs
+++ b/benches/generated/rounding_total_fractial_nested.rs
@@ -1,13 +1,13 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0.3f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(9.9f32), ..Default::default() },
-                position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(13.3f32),
+                flex_basis: taffy::style::Dimension::Points(0.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(9.9f32), ..Default::default() },
+                position: taffy::geometry::Rect {
+                    bottom: taffy::style::Dimension::Points(13.3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,66 +15,57 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Points(0.3f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(1.1f32), ..Default::default() },
-                position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(13.3f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(0.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(1.1f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(13.3f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 0.7f32,
-                flex_basis: sprawl::style::Dimension::Points(50.3f32),
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(20.3f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(50.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20.3f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00, node01],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.6f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.1f32,
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(10.7f32),
-                    ..Default::default()
-                },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10.7f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(87.4f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(87.4f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -82,5 +73,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/size_defined_by_child.rs
+++ b/benches/generated/size_defined_by_child.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,6 +13,6 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_border.rs
+++ b/benches/generated/size_defined_by_child_with_border.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,14 +13,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/size_defined_by_child_with_padding.rs
+++ b/benches/generated/size_defined_by_child_with_padding.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,14 +13,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,5 +28,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/size_defined_by_grand_child.rs
+++ b/benches/generated/size_defined_by_grand_child.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,7 +13,7 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,17 +37,17 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/benches/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,23 +13,23 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,25 +37,25 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_column.rs
+++ b/benches/generated/wrap_column.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(31f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(31f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(32f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(32f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(33f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(33f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(34f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(34f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,14 +52,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -67,5 +67,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,18 +13,18 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node000],
         )
         .unwrap();
-    let node010 = sprawl
+    let node010 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,33 +32,33 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node010],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(70f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(70f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,5 +66,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/benches/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,18 +13,18 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node000],
         )
         .unwrap();
-    let node010 = sprawl
+    let node010 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,33 +32,33 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node010],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(85f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(85f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,5 +66,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_column.rs
+++ b/benches/generated/wrap_reverse_column.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(31f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(31f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(32f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(32f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(33f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(33f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(34f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(34f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,14 +52,14 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -67,5 +67,5 @@ pub fn compute() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_column_fixed_size.rs
+++ b/benches/generated/wrap_reverse_column_fixed_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,15 +65,15 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -81,5 +81,5 @@ pub fn compute() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_row.rs
+++ b/benches/generated/wrap_reverse_row.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(31f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(31f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(32f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(32f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(33f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(33f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(34f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(34f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,15 +52,15 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_center.rs
+++ b/benches/generated/wrap_reverse_row_align_content_center.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,16 +65,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/benches/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,16 +65,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::FlexStart,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::FlexStart,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/benches/generated/wrap_reverse_row_align_content_space_around.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,16 +65,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::SpaceAround,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::SpaceAround,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/benches/generated/wrap_reverse_row_align_content_stretch.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,15 +65,15 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/benches/generated/wrap_reverse_row_single_line_different_size.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,12 +52,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,16 +65,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::FlexStart,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(300f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::FlexStart,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(300f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_row.rs
+++ b/benches/generated/wrap_row.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(31f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(31f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(32f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(32f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(33f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(33f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(34f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(34f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,15 +52,15 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_row_align_items_center.rs
+++ b/benches/generated/wrap_row_align_items_center.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,16 +52,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrap_row_align_items_flex_end.rs
+++ b/benches/generated/wrap_row_align_items_flex_end.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,12 +26,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,12 +39,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,16 +52,16 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::FlexEnd,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrapped_column_max_height.rs
+++ b/benches/generated/wrapped_column_max_height.rs
@@ -1,15 +1,15 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -17,32 +17,19 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node2 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -50,17 +37,30 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::Center,
-                align_content: sprawl::style::AlignContent::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(700f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::Center,
+                align_content: taffy::style::AlignContent::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(700f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -68,5 +68,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrapped_column_max_height_flex.rs
+++ b/benches/generated/wrapped_column_max_height_flex.rs
@@ -1,18 +1,18 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,35 +20,22 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node2 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -56,17 +43,30 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::Center,
-                align_content: sprawl::style::AlignContent::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(700f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::Center,
+                align_content: taffy::style::AlignContent::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(700f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -74,5 +74,5 @@ pub fn compute() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_center.rs
+++ b/benches/generated/wrapped_row_within_align_items_center.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(80f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,20 +26,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_wrap: sprawl::style::FlexWrap::Wrap, ..Default::default() },
+            taffy::style::Style { flex_wrap: taffy::style::FlexWrap::Wrap, ..Default::default() },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_end.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(80f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,20 +26,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_wrap: sprawl::style::FlexWrap::Wrap, ..Default::default() },
+            taffy::style::Style { flex_wrap: taffy::style::FlexWrap::Wrap, ..Default::default() },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/benches/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/benches/generated/wrapped_row_within_align_items_flex_start.rs
@@ -1,11 +1,11 @@
 pub fn compute() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -13,12 +13,12 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(80f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,20 +26,20 @@ pub fn compute() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_wrap: sprawl::style::FlexWrap::Wrap, ..Default::default() },
+            taffy::style::Style { flex_wrap: taffy::style::FlexWrap::Wrap, ..Default::default() },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -47,5 +47,5 @@ pub fn compute() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,14 +1,14 @@
-use sprawl::prelude::*;
+use taffy::prelude::*;
 
 fn main() -> Result<(), Error> {
-    let mut sprawl = Sprawl::new();
+    let mut taffy = Taffy::new();
 
-    let child = sprawl.new_node(
+    let child = taffy.new_node(
         Style { size: Size { width: Dimension::Percent(0.5), height: Dimension::Auto }, ..Default::default() },
         &[],
     )?;
 
-    let node = sprawl.new_node(
+    let node = taffy.new_node(
         Style {
             size: Size { width: Dimension::Points(100.0), height: Dimension::Points(100.0) },
             justify_content: JustifyContent::Center,
@@ -17,13 +17,13 @@ fn main() -> Result<(), Error> {
         &[child],
     )?;
 
-    sprawl.compute_layout(node, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
+    taffy.compute_layout(node, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
 
     // or just use undefined for 100 x 100
-    // sprawl.compute_layout(node, Size::undefined())?;
+    // taffy.compute_layout(node, Size::undefined())?;
 
-    println!("node: {:#?}", sprawl.layout(node)?);
-    println!("child: {:#?}", sprawl.layout(child)?);
+    println!("node: {:#?}", taffy.layout(node)?);
+    println!("child: {:#?}", taffy.layout(child)?);
 
     Ok(())
 }

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,15 +1,15 @@
-use sprawl::prelude::*;
+use taffy::prelude::*;
 
 fn main() -> Result<(), Error> {
-    let mut sprawl = Sprawl::new();
+    let mut taffy = Taffy::new();
 
     // left
-    let child_t1 = sprawl.new_node(
+    let child_t1 = taffy.new_node(
         Style { size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, ..Default::default() },
         &[],
     )?;
 
-    let div1 = sprawl.new_node(
+    let div1 = taffy.new_node(
         Style {
             size: Size { width: Dimension::Percent(0.5), height: Dimension::Percent(1.0) },
             // justify_content: JustifyContent::Center,
@@ -19,12 +19,12 @@ fn main() -> Result<(), Error> {
     )?;
 
     // right
-    let child_t2 = sprawl.new_node(
+    let child_t2 = taffy.new_node(
         Style { size: Size { width: Dimension::Points(5.0), height: Dimension::Points(5.0) }, ..Default::default() },
         &[],
     )?;
 
-    let div2 = sprawl.new_node(
+    let div2 = taffy.new_node(
         Style {
             size: Size { width: Dimension::Percent(0.5), height: Dimension::Percent(1.0) },
             // justify_content: JustifyContent::Center,
@@ -33,20 +33,20 @@ fn main() -> Result<(), Error> {
         &[child_t2],
     )?;
 
-    let container = sprawl.new_node(
+    let container = taffy.new_node(
         Style { size: Size { width: Dimension::Percent(1.0), height: Dimension::Percent(1.0) }, ..Default::default() },
         &[div1, div2],
     )?;
 
-    sprawl.compute_layout(container, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
+    taffy.compute_layout(container, Size { height: Number::Defined(100.0), width: Number::Defined(100.0) })?;
 
-    println!("node: {:#?}", sprawl.layout(container)?);
+    println!("node: {:#?}", taffy.layout(container)?);
 
-    println!("div1: {:#?}", sprawl.layout(div1)?);
-    println!("div2: {:#?}", sprawl.layout(div2)?);
+    println!("div1: {:#?}", taffy.layout(div1)?);
+    println!("div2: {:#?}", taffy.layout(div2)?);
 
-    println!("child1: {:#?}", sprawl.layout(child_t1)?);
-    println!("child2: {:#?}", sprawl.layout(child_t2)?);
+    println!("child1: {:#?}", taffy.layout(child_t1)?);
+    println!("child2: {:#?}", taffy.layout(child_t2)?);
 
     Ok(())
 }

--- a/scripts/gentest/src/main.rs
+++ b/scripts/gentest/src/main.rs
@@ -185,9 +185,9 @@ fn generate_bench(description: &json::JsonValue) -> TokenStream {
 
     quote!(
         pub fn compute() {
-            let mut stretch = sprawl::Stretch::new();
+            let mut stretch = taffy::Stretch::new();
             #node_description
-            stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+            stretch.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
         }
     )
 }
@@ -201,9 +201,9 @@ fn generate_test(name: impl AsRef<str>, description: &json::JsonValue) -> TokenS
     quote!(
         #[test]
         fn #name() {
-            let mut stretch = sprawl::Stretch::new();
+            let mut stretch = taffy::Stretch::new();
             #node_description
-            stretch.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+            stretch.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
             #assertions
         }
     )
@@ -249,7 +249,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let display = match style["display"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "none" => quote!(display: sprawl::style::Display::None,),
+            "none" => quote!(display: taffy::style::Display::None,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -257,7 +257,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let position_type = match style["position_type"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "absolute" => quote!(position_type: sprawl::style::PositionType::Absolute,),
+            "absolute" => quote!(position_type: taffy::style::PositionType::Absolute,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -265,8 +265,8 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let direction = match style["direction"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "rtl" => quote!(direction: sprawl::style::Direction::RTL,),
-            "ltr" => quote!(direction: sprawl::style::Direction::LTR,),
+            "rtl" => quote!(direction: taffy::style::Direction::RTL,),
+            "ltr" => quote!(direction: taffy::style::Direction::LTR,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -274,9 +274,9 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let flex_direction = match style["flexDirection"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "row-reverse" => quote!(flex_direction: sprawl::style::FlexDirection::RowReverse,),
-            "column" => quote!(flex_direction: sprawl::style::FlexDirection::Column,),
-            "column-reverse" => quote!(flex_direction: sprawl::style::FlexDirection::ColumnReverse,),
+            "row-reverse" => quote!(flex_direction: taffy::style::FlexDirection::RowReverse,),
+            "column" => quote!(flex_direction: taffy::style::FlexDirection::Column,),
+            "column-reverse" => quote!(flex_direction: taffy::style::FlexDirection::ColumnReverse,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -284,8 +284,8 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let flex_wrap = match style["flexWrap"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "wrap" => quote!(flex_wrap: sprawl::style::FlexWrap::Wrap,),
-            "wrap-reverse" => quote!(flex_wrap: sprawl::style::FlexWrap::WrapReverse,),
+            "wrap" => quote!(flex_wrap: taffy::style::FlexWrap::Wrap,),
+            "wrap-reverse" => quote!(flex_wrap: taffy::style::FlexWrap::WrapReverse,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -293,8 +293,8 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let overflow = match style["overflow"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "hidden" => quote!(overflow: sprawl::style::Overflow::Hidden,),
-            "scroll" => quote!(overflow: sprawl::style::Overflow::Scroll,),
+            "hidden" => quote!(overflow: taffy::style::Overflow::Hidden,),
+            "scroll" => quote!(overflow: taffy::style::Overflow::Scroll,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -302,10 +302,10 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let align_items = match style["alignItems"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "flex-start" => quote!(align_items: sprawl::style::AlignItems::FlexStart,),
-            "flex-end" => quote!(align_items: sprawl::style::AlignItems::FlexEnd,),
-            "center" => quote!(align_items: sprawl::style::AlignItems::Center,),
-            "baseline" => quote!(align_items: sprawl::style::AlignItems::Baseline,),
+            "flex-start" => quote!(align_items: taffy::style::AlignItems::FlexStart,),
+            "flex-end" => quote!(align_items: taffy::style::AlignItems::FlexEnd,),
+            "center" => quote!(align_items: taffy::style::AlignItems::Center,),
+            "baseline" => quote!(align_items: taffy::style::AlignItems::Baseline,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -313,11 +313,11 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let align_self = match style["alignSelf"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "flex-start" => quote!(align_self: sprawl::style::AlignSelf::FlexStart,),
-            "flex-end" => quote!(align_self: sprawl::style::AlignSelf::FlexEnd,),
-            "center" => quote!(align_self: sprawl::style::AlignSelf::Center,),
-            "baseline" => quote!(align_self: sprawl::style::AlignSelf::Baseline,),
-            "stretch" => quote!(align_self: sprawl::style::AlignSelf::Stretch,),
+            "flex-start" => quote!(align_self: taffy::style::AlignSelf::FlexStart,),
+            "flex-end" => quote!(align_self: taffy::style::AlignSelf::FlexEnd,),
+            "center" => quote!(align_self: taffy::style::AlignSelf::Center,),
+            "baseline" => quote!(align_self: taffy::style::AlignSelf::Baseline,),
+            "stretch" => quote!(align_self: taffy::style::AlignSelf::Stretch,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -325,11 +325,11 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let align_content = match style["alignContent"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "flex-start" => quote!(align_content: sprawl::style::AlignContent::FlexStart,),
-            "flex-end" => quote!(align_content: sprawl::style::AlignContent::FlexEnd,),
-            "center" => quote!(align_content: sprawl::style::AlignContent::Center,),
-            "space-between" => quote!(align_content: sprawl::style::AlignContent::SpaceBetween,),
-            "space-around" => quote!(align_content: sprawl::style::AlignContent::SpaceAround,),
+            "flex-start" => quote!(align_content: taffy::style::AlignContent::FlexStart,),
+            "flex-end" => quote!(align_content: taffy::style::AlignContent::FlexEnd,),
+            "center" => quote!(align_content: taffy::style::AlignContent::Center,),
+            "space-between" => quote!(align_content: taffy::style::AlignContent::SpaceBetween,),
+            "space-around" => quote!(align_content: taffy::style::AlignContent::SpaceAround,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -337,11 +337,11 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
 
     let justify_content = match style["justifyContent"] {
         json::JsonValue::Short(ref value) => match value.as_ref() {
-            "flex-end" => quote!(justify_content: sprawl::style::JustifyContent::FlexEnd,),
-            "center" => quote!(justify_content: sprawl::style::JustifyContent::Center,),
-            "space-between" => quote!(justify_content: sprawl::style::JustifyContent::SpaceBetween,),
-            "space-around" => quote!(justify_content: sprawl::style::JustifyContent::SpaceAround,),
-            "space-evenly" => quote!(justify_content: sprawl::style::JustifyContent::SpaceEvenly,),
+            "flex-end" => quote!(justify_content: taffy::style::JustifyContent::FlexEnd,),
+            "center" => quote!(justify_content: taffy::style::JustifyContent::Center,),
+            "space-between" => quote!(justify_content: taffy::style::JustifyContent::SpaceBetween,),
+            "space-around" => quote!(justify_content: taffy::style::JustifyContent::SpaceAround,),
+            "space-evenly" => quote!(justify_content: taffy::style::JustifyContent::SpaceEvenly,),
             _ => quote!(),
         },
         _ => quote!(),
@@ -438,7 +438,7 @@ fn generate_node(ident: &str, node: &json::JsonValue) -> TokenStream {
     quote!(
         #children_body
         let #ident = stretch.new_node(
-        sprawl::style::Style {
+        taffy::style::Style {
             #display
             #direction
             #position_type
@@ -481,7 +481,7 @@ fn generate_size(size: &json::object::Object) -> TokenStream {
     dim_quoted!(size, width);
     dim_quoted!(size, height);
     quote!(
-        sprawl::geometry::Size {
+        taffy::geometry::Size {
             #width #height
             ..Default::default()
         }
@@ -494,14 +494,14 @@ fn generate_dimension(dimen: &json::object::Object) -> TokenStream {
 
     match unit {
         json::JsonValue::Short(ref unit) => match unit.as_ref() {
-            "auto" => quote!(sprawl::style::Dimension::Auto),
+            "auto" => quote!(taffy::style::Dimension::Auto),
             "points" => {
                 let value = value();
-                quote!(sprawl::style::Dimension::Points(#value))
+                quote!(taffy::style::Dimension::Points(#value))
             }
             "percent" => {
                 let value = value();
-                quote!(sprawl::style::Dimension::Percent(#value))
+                quote!(taffy::style::Dimension::Percent(#value))
             }
             _ => unreachable!(),
         },
@@ -515,7 +515,7 @@ fn generate_edges(dimen: &json::object::Object) -> TokenStream {
     dim_quoted!(dimen, top);
     dim_quoted!(dimen, bottom);
 
-    quote!(sprawl::geometry::Rect {
+    quote!(taffy::geometry::Rect {
         #start #end #top #bottom
         ..Default::default()
     })

--- a/src/flexbox.rs
+++ b/src/flexbox.rs
@@ -1,6 +1,6 @@
 //! Computes the [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) layout algorithm on a [`Forest`](crate::forest::Forest) according to the [spec](https://www.w3.org/TR/css-flexbox-1/)
 //!
-//! Note that some minor steps appear to be missing: see https://github.com/DioxusLabs/sprawl/issues for more information.
+//! Note that some minor steps appear to be missing: see https://github.com/DioxusLabs/taffy/issues for more information.
 use core::f32;
 
 use crate::flexbox::Number::{Defined, Undefined};

--- a/src/forest.rs
+++ b/src/forest.rs
@@ -1,6 +1,6 @@
 //! Forest - a struct-of-arrays data structure for storing node trees.
 //!
-//! Backing datastructure for `Sprawl` structs.
+//! Backing datastructure for `Taffy` structs.
 use crate::geometry::Size;
 use crate::layout::{Cache, Layout};
 use crate::node::{MeasureFunc, NodeId};

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1253,10 +1253,10 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use vec::Vec;
 
-/// A [`sprawl::indexmap::IndexMap`](./struct.IndexMap.html) using the default FNV hasher
+/// A [`taffy::indexmap::IndexMap`](./struct.IndexMap.html) using the default FNV hasher
 ///
 /// A list of all Methods and Traits available for `FnvIndexMap` can be found in
-/// the [`sprawl::indexmap::IndexMap`](./struct.IndexMap.html) documentation.
+/// the [`taffy::indexmap::IndexMap`](./struct.IndexMap.html) documentation.
 pub type FnvIndexMap<K, V, const N: usize> = IndexMap<K, V, BuildHasherDefault<FnvHasher>, N>;
 
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod forest;
 mod indexmap;
 mod sys;
 
-pub use crate::node::Sprawl;
+pub use crate::node::Taffy;
 
 #[cfg(feature = "std")]
 use core::fmt::{Display, Formatter, Result};
@@ -49,7 +49,7 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::InvalidNode(_) => "The node is not part of the Sprawl instance",
+            Error::InvalidNode(_) => "The node is not part of the Taffy instance",
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,7 +21,7 @@ pub enum MeasureFunc {
     Boxed(Box<dyn Fn(Size<Number>) -> Size<f32>>),
 }
 
-/// Global sprawl instance id allocator.
+/// Global taffy instance id allocator.
 static INSTANCE_ALLOCATOR: Allocator = Allocator::new();
 
 /// An [`Id`]-containing identifier
@@ -35,7 +35,7 @@ pub struct Node {
 }
 
 /// A forest of UI [`Nodes`](`Node`), suitable for UI layout
-pub struct Sprawl {
+pub struct Taffy {
     /// The ID of the root node
     id: Id,
     /// A monotonically-increasing index that tracks the [`Id`] of the next node
@@ -48,22 +48,22 @@ pub struct Sprawl {
     forest: Forest,
 }
 
-impl Default for Sprawl {
+impl Default for Taffy {
     fn default() -> Self {
         Self::with_capacity(16)
     }
 }
 
-impl Sprawl {
-    /// Creates a new [`Sprawl`]
+impl Taffy {
+    /// Creates a new [`Taffy`]
     ///
-    /// The default capacity of a [`Sprawl`] is 16 nodes.
+    /// The default capacity of a [`Taffy`] is 16 nodes.
     #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Creates a new [`Sprawl`] that can store `capacity` nodes before reallocation
+    /// Creates a new [`Taffy`] that can store `capacity` nodes before reallocation
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             id: INSTANCE_ALLOCATOR.allocate(),
@@ -280,7 +280,7 @@ pub(crate) type NodeId = usize;
 #[cfg_attr(not(any(feature = "std", feature = "alloc")), derive(hash32_derive::Hash32))]
 pub(crate) struct Id(usize);
 
-/// An bump-allocator index that tracks how many [`Nodes`](Node) have been allocated in a [`Sprawl`].
+/// An bump-allocator index that tracks how many [`Nodes`](Node) have been allocated in a [`Taffy`].
 pub(crate) struct Allocator {
     /// The last reserved [`NodeId`]
     last_id: AtomicUsize,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,7 @@
 pub use crate::{
     geometry::{Rect, Size},
     layout::Layout,
-    node::{Node, Sprawl},
+    node::{Node, Taffy},
     number::Number,
     style::{
         AlignContent, AlignItems, AlignSelf, Dimension, Display, FlexDirection, FlexWrap, JustifyContent, PositionType,

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center.rs
@@ -1,13 +1,13 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ fn absolute_layout_align_items_and_justify_content_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn absolute_layout_align_items_and_justify_content_center() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
 }

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_bottom_position.rs
@@ -1,17 +1,17 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,14 +19,14 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,13 +34,13 @@ fn absolute_layout_align_items_and_justify_content_center_and_bottom_position() 
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 50f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 50f32);
 }

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_left_position.rs
@@ -1,32 +1,29 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    ..Default::default()
-                },
+                position: taffy::geometry::Rect { start: taffy::style::Dimension::Points(5f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,13 +31,13 @@ fn absolute_layout_align_items_and_justify_content_center_and_left_position() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 5f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 5f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
 }

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_right_position.rs
@@ -1,29 +1,29 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(5f32), ..Default::default() },
+                position: taffy::geometry::Rect { end: taffy::style::Dimension::Points(5f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn absolute_layout_align_items_and_justify_content_center_and_right_position() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 45f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 45f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
 }

--- a/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_center_and_top_position.rs
@@ -1,29 +1,29 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn absolute_layout_align_items_and_justify_content_center_and_top_position() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
+++ b/tests/generated/absolute_layout_align_items_and_justify_content_flex_end.rs
@@ -1,13 +1,13 @@
 #[test]
 fn absolute_layout_align_items_and_justify_content_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexEnd,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn absolute_layout_align_items_and_justify_content_flex_end() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 60f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 60f32);
 }

--- a/tests/generated/absolute_layout_align_items_center.rs
+++ b/tests/generated/absolute_layout_align_items_center.rs
@@ -1,13 +1,13 @@
 #[test]
 fn absolute_layout_align_items_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn absolute_layout_align_items_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn absolute_layout_align_items_center() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
 }

--- a/tests/generated/absolute_layout_align_items_center_on_child_only.rs
+++ b/tests/generated/absolute_layout_align_items_center_on_child_only.rs
@@ -1,14 +1,14 @@
 #[test]
 fn absolute_layout_align_items_center_on_child_only() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                align_self: sprawl::style::AlignSelf::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                align_self: taffy::style::AlignSelf::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,12 +16,12 @@ fn absolute_layout_align_items_center_on_child_only() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn absolute_layout_align_items_center_on_child_only() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
 }

--- a/tests/generated/absolute_layout_child_order.rs
+++ b/tests/generated/absolute_layout_child_order.rs
@@ -1,12 +1,12 @@
 #[test]
 fn absolute_layout_child_order() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn absolute_layout_child_order() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,12 +28,12 @@ fn absolute_layout_child_order() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,14 +41,14 @@ fn absolute_layout_child_order() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -56,21 +56,21 @@ fn absolute_layout_child_order() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 55f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 55f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 55f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 55f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 55f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 55f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 30f32);
 }

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container.rs
@@ -1,13 +1,13 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_column_container() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,14 +15,14 @@ fn absolute_layout_in_wrap_reverse_column_container() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn absolute_layout_in_wrap_reverse_column_container() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_column_container_flex_end.rs
@@ -1,14 +1,14 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,14 +16,14 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn absolute_layout_in_wrap_reverse_column_container_flex_end() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container.rs
@@ -1,13 +1,13 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_row_container() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn absolute_layout_in_wrap_reverse_row_container() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn absolute_layout_in_wrap_reverse_row_container() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 80f32);
 }

--- a/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
+++ b/tests/generated/absolute_layout_in_wrap_reverse_row_container_flex_end.rs
@@ -1,14 +1,14 @@
 #[test]
 fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,13 +16,13 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn absolute_layout_in_wrap_reverse_row_container_flex_end() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/absolute_layout_justify_content_center.rs
+++ b/tests/generated/absolute_layout_justify_content_center.rs
@@ -1,13 +1,13 @@
 #[test]
 fn absolute_layout_justify_content_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn absolute_layout_justify_content_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(110f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(110f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn absolute_layout_justify_content_center() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/absolute_layout_no_size.rs
+++ b/tests/generated/absolute_layout_no_size.rs
@@ -1,18 +1,18 @@
 #[test]
 fn absolute_layout_no_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },
+            taffy::style::Style { position_type: taffy::style::PositionType::Absolute, ..Default::default() },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,13 +20,13 @@ fn absolute_layout_no_size() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
+++ b/tests/generated/absolute_layout_percentage_bottom_based_on_parent_height.rs
@@ -1,17 +1,32 @@
 #[test]
 fn absolute_layout_percentage_bottom_based_on_parent_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.5f32),
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Percent(0.5f32), ..Default::default() },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node1 = taffy
+        .new_node(
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
+                    ..Default::default()
+                },
+                position: taffy::geometry::Rect {
+                    bottom: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,17 +34,14 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
-                position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Percent(0.5f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Percent(0.1f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,27 +49,12 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,21 +62,21 @@ fn absolute_layout_percentage_bottom_based_on_parent_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 90f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 160f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 90f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 160f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 20f32);
 }

--- a/tests/generated/absolute_layout_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_start_top_end_bottom.rs
@@ -1,15 +1,15 @@
 #[test]
 fn absolute_layout_start_top_end_bottom() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -17,12 +17,12 @@ fn absolute_layout_start_top_end_bottom() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn absolute_layout_start_top_end_bottom() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/absolute_layout_width_height_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_end_bottom.rs
@@ -1,18 +1,18 @@
 #[test]
 fn absolute_layout_width_height_end_bottom() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,12 +20,12 @@ fn absolute_layout_width_height_end_bottom() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn absolute_layout_width_height_end_bottom() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 80f32);
 }

--- a/tests/generated/absolute_layout_width_height_start_top.rs
+++ b/tests/generated/absolute_layout_width_height_start_top.rs
@@ -1,18 +1,18 @@
 #[test]
 fn absolute_layout_width_height_start_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,12 +20,12 @@ fn absolute_layout_width_height_start_top() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn absolute_layout_width_height_start_top() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
+++ b/tests/generated/absolute_layout_width_height_start_top_end_bottom.rs
@@ -1,20 +1,20 @@
 #[test]
 fn absolute_layout_width_height_start_top_end_bottom() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,12 +22,12 @@ fn absolute_layout_width_height_start_top_end_bottom() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,13 +35,13 @@ fn absolute_layout_width_height_start_top_end_bottom() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/absolute_layout_within_border.rs
+++ b/tests/generated/absolute_layout_within_border.rs
@@ -1,18 +1,18 @@
 #[test]
 fn absolute_layout_within_border() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(0f32),
+                    top: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,18 +20,18 @@ fn absolute_layout_within_border() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Points(0f32),
+                    bottom: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -39,25 +39,25 @@ fn absolute_layout_within_border() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(0f32),
-                    top: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(0f32),
+                    top: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -65,25 +65,25 @@ fn absolute_layout_within_border() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Points(0f32),
-                    bottom: sprawl::style::Dimension::Points(0f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Points(0f32),
+                    bottom: taffy::style::Dimension::Points(0f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -91,26 +91,26 @@ fn absolute_layout_within_border() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -118,25 +118,25 @@ fn absolute_layout_within_border() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 40f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 20f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 40f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 20f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 30f32);
 }

--- a/tests/generated/align_baseline.rs
+++ b/tests/generated/align_baseline.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_baseline() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn align_baseline() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ fn align_baseline() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,17 +41,17 @@ fn align_baseline() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 30f32);
 }

--- a/tests/generated/align_baseline_child_multiline.rs
+++ b/tests/generated/align_baseline_child_multiline.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_baseline_child_multiline() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(60f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn align_baseline_child_multiline() {
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn align_baseline_child_multiline() {
             &[],
         )
         .unwrap();
-    let node11 = sprawl
+    let node11 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn align_baseline_child_multiline() {
             &[],
         )
         .unwrap();
-    let node12 = sprawl
+    let node12 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn align_baseline_child_multiline() {
             &[],
         )
         .unwrap();
-    let node13 = sprawl
+    let node13 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(25f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(25f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,53 +66,53 @@ fn align_baseline_child_multiline() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10, node11, node12, node13],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Baseline,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Baseline,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 25f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node11).unwrap().size.width, 25f32);
-    assert_eq!(sprawl.layout(node11).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node11).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node11).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node12).unwrap().size.width, 25f32);
-    assert_eq!(sprawl.layout(node12).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node12).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node12).unwrap().location.y, 20f32);
-    assert_eq!(sprawl.layout(node13).unwrap().size.width, 25f32);
-    assert_eq!(sprawl.layout(node13).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node13).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node13).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 25f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node11).unwrap().size.width, 25f32);
+    assert_eq!(taffy.layout(node11).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node11).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node11).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node12).unwrap().size.width, 25f32);
+    assert_eq!(taffy.layout(node12).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node12).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node12).unwrap().location.y, 20f32);
+    assert_eq!(taffy.layout(node13).unwrap().size.width, 25f32);
+    assert_eq!(taffy.layout(node13).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node13).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node13).unwrap().location.y, 20f32);
 }

--- a/tests/generated/align_baseline_nested_child.rs
+++ b/tests/generated/align_baseline_nested_child.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_baseline_nested_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn align_baseline_nested_child() {
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ fn align_baseline_nested_child() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,13 +41,13 @@ fn align_baseline_nested_child() {
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -55,21 +55,21 @@ fn align_baseline_nested_child() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_center_should_size_based_on_content.rs
+++ b/tests/generated/align_center_should_size_based_on_content.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_center_should_size_based_on_content() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn align_center_should_size_based_on_content() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_center_should_size_based_on_content() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn align_center_should_size_based_on_content() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_flex_start_with_shrinking_children.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children.rs
@@ -1,24 +1,23 @@
 #[test]
 fn align_flex_start_with_shrinking_children() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
+    let mut taffy = taffy::Taffy::new();
+    let node000 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
-        .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexStart, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexStart, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,21 +25,21 @@ fn align_flex_start_with_shrinking_children() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
+++ b/tests/generated/align_flex_start_with_shrinking_children_with_stretch.rs
@@ -1,24 +1,23 @@
 #[test]
 fn align_flex_start_with_shrinking_children_with_stretch() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
+    let mut taffy = taffy::Taffy::new();
+    let node000 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
-        .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexStart, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexStart, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,21 +25,21 @@ fn align_flex_start_with_shrinking_children_with_stretch() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_flex_start_with_stretching_children.rs
+++ b/tests/generated/align_flex_start_with_stretching_children.rs
@@ -1,19 +1,18 @@
 #[test]
 fn align_flex_start_with_stretching_children() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
+    let mut taffy = taffy::Taffy::new();
+    let node000 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
-        .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -21,21 +20,21 @@ fn align_flex_start_with_stretching_children() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_center.rs
+++ b/tests/generated/align_items_center.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_items_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn align_items_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_items_center() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 45f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 45f32);
 }

--- a/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_with_margin_bigger_than_parent.rs
@@ -1,17 +1,17 @@
 #[test]
 fn align_items_center_child_with_margin_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,20 +19,20 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::Center, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::Center, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,17 +40,17 @@ fn align_items_center_child_with_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, -10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, -10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_center_child_without_margin_bigger_than_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_items_center_child_without_margin_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(70f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(70f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,20 +14,20 @@ fn align_items_center_child_without_margin_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::Center, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::Center, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,17 +35,17 @@ fn align_items_center_child_without_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, -10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, -10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, -10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, -10f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_center_with_child_margin.rs
+++ b/tests/generated/align_items_center_with_child_margin.rs
@@ -1,27 +1,27 @@
 #[test]
 fn align_items_center_with_child_margin() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn align_items_center_with_child_margin() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 50f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 50f32);
 }

--- a/tests/generated/align_items_center_with_child_top.rs
+++ b/tests/generated/align_items_center_with_child_top.rs
@@ -1,27 +1,27 @@
 #[test]
 fn align_items_center_with_child_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn align_items_center_with_child_top() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 55f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 55f32);
 }

--- a/tests/generated/align_items_flex_end.rs
+++ b/tests/generated/align_items_flex_end.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_items_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_items_flex_end() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 90f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 90f32);
 }

--- a/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_with_margin_bigger_than_parent.rs
@@ -1,17 +1,17 @@
 #[test]
 fn align_items_flex_end_child_with_margin_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,20 +19,20 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexEnd, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexEnd, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,17 +40,17 @@ fn align_items_flex_end_child_with_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, -10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, -10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
+++ b/tests/generated/align_items_flex_end_child_without_margin_bigger_than_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_items_flex_end_child_without_margin_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(70f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(70f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,20 +14,20 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { align_items: sprawl::style::AlignItems::FlexEnd, ..Default::default() },
+            taffy::style::Style { align_items: taffy::style::AlignItems::FlexEnd, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,17 +35,17 @@ fn align_items_flex_end_child_without_margin_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, -10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, -10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, -10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, -10f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_flex_start.rs
+++ b/tests/generated/align_items_flex_start.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_items_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn align_items_flex_start() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_items_flex_start() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_min_max.rs
+++ b/tests/generated/align_items_min_max.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_items_min_max() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(60f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,18 +14,18 @@ fn align_items_min_max() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn align_items_min_max() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_items_stretch.rs
+++ b/tests/generated/align_items_stretch.rs
@@ -1,21 +1,21 @@
 #[test]
 fn align_items_stretch() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,13 +23,13 @@ fn align_items_stretch() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_self_baseline.rs
+++ b/tests/generated/align_self_baseline.rs
@@ -1,13 +1,13 @@
 #[test]
 fn align_self_baseline() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ fn align_self_baseline() {
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_self_baseline() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::Baseline,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::Baseline,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,12 +42,12 @@ fn align_self_baseline() {
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -55,21 +55,21 @@ fn align_self_baseline() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_self_center.rs
+++ b/tests/generated/align_self_center.rs
@@ -1,13 +1,13 @@
 #[test]
 fn align_self_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ fn align_self_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_self_center() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 45f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 45f32);
 }

--- a/tests/generated/align_self_flex_end.rs
+++ b/tests/generated/align_self_flex_end.rs
@@ -1,13 +1,13 @@
 #[test]
 fn align_self_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ fn align_self_flex_end() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_self_flex_end() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 90f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 90f32);
 }

--- a/tests/generated/align_self_flex_end_override_flex_start.rs
+++ b/tests/generated/align_self_flex_end_override_flex_start.rs
@@ -1,13 +1,13 @@
 #[test]
 fn align_self_flex_end_override_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn align_self_flex_end_override_flex_start() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn align_self_flex_end_override_flex_start() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 90f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 90f32);
 }

--- a/tests/generated/align_self_flex_start.rs
+++ b/tests/generated/align_self_flex_start.rs
@@ -1,13 +1,13 @@
 #[test]
 fn align_self_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::style::AlignSelf::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                align_self: taffy::style::AlignSelf::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ fn align_self_flex_start() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn align_self_flex_start() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/align_strech_should_size_based_on_parent.rs
+++ b/tests/generated/align_strech_should_size_based_on_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn align_strech_should_size_based_on_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn align_strech_should_size_based_on_parent() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
+    let node00 = taffy
+        .new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[node000])
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
                 ..Default::default()
@@ -28,12 +28,12 @@ fn align_strech_should_size_based_on_parent() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,21 +41,21 @@ fn align_strech_should_size_based_on_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/border_center_child.rs
+++ b/tests/generated/border_center_child.rs
@@ -1,12 +1,12 @@
 #[test]
 fn border_center_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,19 +14,19 @@ fn border_center_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                border: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,13 +34,13 @@ fn border_center_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 45f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 40f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 45f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 40f32);
 }

--- a/tests/generated/border_flex_child.rs
+++ b/tests/generated/border_flex_child.rs
@@ -1,29 +1,29 @@
 #[test]
 fn border_flex_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn border_flex_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/border_no_child.rs
+++ b/tests/generated/border_no_child.rs
@@ -1,14 +1,14 @@
 #[test]
 fn border_no_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,9 +16,9 @@ fn border_no_child() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
 }

--- a/tests/generated/border_stretch_child.rs
+++ b/tests/generated/border_stretch_child.rs
@@ -1,28 +1,28 @@
 #[test]
 fn border_stretch_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn border_stretch_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/child_min_max_width_flexing.rs
+++ b/tests/generated/child_min_max_width_flexing.rs
@@ -1,42 +1,36 @@
 #[test]
 fn child_min_max_width_flexing() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(0f32),
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(120f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(120f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,17 +38,17 @@ fn child_min_max_width_flexing() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 120f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 120f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/container_with_unsized_child.rs
+++ b/tests/generated/container_with_unsized_child.rs
@@ -1,13 +1,13 @@
 #[test]
 fn container_with_unsized_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn container_with_unsized_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/display_none.rs
+++ b/tests/generated/display_none.rs
@@ -1,19 +1,19 @@
 #[test]
 fn display_none() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style { display: sprawl::style::Display::None, flex_grow: 1f32, ..Default::default() },
+            taffy::style::Style { display: taffy::style::Display::None, flex_grow: 1f32, ..Default::default() },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -21,17 +21,17 @@ fn display_none() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/display_none_fixed_size.rs
+++ b/tests/generated/display_none_fixed_size.rs
@@ -1,14 +1,14 @@
 #[test]
 fn display_none_fixed_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                display: taffy::style::Display::None,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,12 +16,12 @@ fn display_none_fixed_size() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,17 +29,17 @@ fn display_none_fixed_size() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/display_none_with_child.rs
+++ b/tests/generated/display_none_with_child.rs
@@ -1,59 +1,59 @@
 #[test]
 fn display_none_with_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                display: taffy::style::Display::None,
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -61,25 +61,25 @@ fn display_none_with_child() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/display_none_with_margin.rs
+++ b/tests/generated/display_none_with_margin.rs
@@ -1,20 +1,20 @@
 #[test]
 fn display_none_with_margin() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                display: taffy::style::Display::None,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -22,13 +22,13 @@ fn display_none_with_margin() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,17 +36,17 @@ fn display_none_with_margin() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/display_none_with_position.rs
+++ b/tests/generated/display_none_with_position.rs
@@ -1,24 +1,24 @@
 #[test]
 fn display_none_with_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                display: sprawl::style::Display::None,
+            taffy::style::Style {
+                display: taffy::style::Display::None,
                 flex_grow: 1f32,
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,17 +26,17 @@ fn display_none_with_position() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
+++ b/tests/generated/flex_basis_and_main_dimen_set_when_flexing.rs
@@ -1,14 +1,14 @@
 #[test]
 fn flex_basis_and_main_dimen_set_when_flexing() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,14 +16,14 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(0f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(0f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,26 +31,26 @@ fn flex_basis_and_main_dimen_set_when_flexing() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_flex_grow_column.rs
+++ b/tests/generated/flex_basis_flex_grow_column.rs
@@ -1,24 +1,24 @@
 #[test]
 fn flex_basis_flex_grow_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,17 +26,17 @@ fn flex_basis_flex_grow_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 75f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 75f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/flex_basis_flex_grow_row.rs
+++ b/tests/generated/flex_basis_flex_grow_row.rs
@@ -1,23 +1,23 @@
 #[test]
 fn flex_basis_flex_grow_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,17 +25,17 @@ fn flex_basis_flex_grow_row() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 75f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 75f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_flex_shrink_column.rs
+++ b/tests/generated/flex_basis_flex_shrink_column.rs
@@ -1,25 +1,22 @@
 #[test]
 fn flex_basis_flex_shrink_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style { flex_basis: taffy::style::Dimension::Points(100f32), ..Default::default() },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-            &[],
-        )
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(50f32), ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,17 +24,17 @@ fn flex_basis_flex_shrink_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 67f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 33f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 67f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 67f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 33f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 67f32);
 }

--- a/tests/generated/flex_basis_flex_shrink_row.rs
+++ b/tests/generated/flex_basis_flex_shrink_row.rs
@@ -1,24 +1,21 @@
 #[test]
 fn flex_basis_flex_shrink_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style { flex_basis: taffy::style::Dimension::Points(100f32), ..Default::default() },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-            &[],
-        )
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(50f32), ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,17 +23,17 @@ fn flex_basis_flex_shrink_row() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 67f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 33f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 67f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 67f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 33f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 67f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_larger_than_content_column.rs
+++ b/tests/generated/flex_basis_larger_than_content_column.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_larger_than_content_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,37 +14,37 @@ fn flex_basis_larger_than_content_column() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_larger_than_content_row.rs
+++ b/tests/generated/flex_basis_larger_than_content_row.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_larger_than_content_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,36 +14,36 @@ fn flex_basis_larger_than_content_row() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_overrides_main_size.rs
+++ b/tests/generated/flex_basis_overrides_main_size.rs
@@ -1,43 +1,43 @@
 #[test]
 fn flex_basis_overrides_main_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,21 +45,21 @@ fn flex_basis_overrides_main_size() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_slightly_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(60f32),
+                flex_basis: taffy::style::Dimension::Points(60f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn flex_basis_slightly_smaller_then_content_with_flex_grow_large_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_than_content_column.rs
+++ b/tests/generated/flex_basis_smaller_than_content_column.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_smaller_than_content_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,37 +14,37 @@ fn flex_basis_smaller_than_content_column() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_than_content_row.rs
+++ b/tests/generated/flex_basis_smaller_than_content_row.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_smaller_than_content_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,36 +14,36 @@ fn flex_basis_smaller_than_content_row() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_basis: taffy::style::Dimension::Points(50f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_column.rs
@@ -1,13 +1,13 @@
 #[test]
 fn flex_basis_smaller_than_main_dimen_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,23 +15,23 @@ fn flex_basis_smaller_than_main_dimen_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
+++ b/tests/generated/flex_basis_smaller_than_main_dimen_row.rs
@@ -1,13 +1,13 @@
 #[test]
 fn flex_basis_smaller_than_main_dimen_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(10f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(10f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,22 +15,22 @@ fn flex_basis_smaller_than_main_dimen_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn flex_basis_smaller_then_content_with_flex_grow_large_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn flex_basis_smaller_then_content_with_flex_grow_small_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,37 +38,37 @@ fn flex_basis_smaller_then_content_with_flex_grow_unconstraint_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 90f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 90f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/flex_basis_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn flex_basis_smaller_then_content_with_flex_grow_very_large_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_unconstraint_column.rs
+++ b/tests/generated/flex_basis_unconstraint_column.rs
@@ -1,29 +1,29 @@
 #[test]
 fn flex_basis_unconstraint_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_basis_unconstraint_row.rs
+++ b/tests/generated/flex_basis_unconstraint_row.rs
@@ -1,24 +1,24 @@
 #[test]
 fn flex_basis_unconstraint_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_direction_column.rs
+++ b/tests/generated/flex_direction_column.rs
@@ -1,40 +1,40 @@
 #[test]
 fn flex_direction_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn flex_direction_column() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 20f32);
 }

--- a/tests/generated/flex_direction_column_no_height.rs
+++ b/tests/generated/flex_direction_column_no_height.rs
@@ -1,58 +1,58 @@
 #[test]
 fn flex_direction_column_no_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 20f32);
 }

--- a/tests/generated/flex_direction_column_reverse.rs
+++ b/tests/generated/flex_direction_column_reverse.rs
@@ -1,40 +1,40 @@
 #[test]
 fn flex_direction_column_reverse() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::ColumnReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::ColumnReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn flex_direction_column_reverse() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 90f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 80f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 70f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 90f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 80f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 70f32);
 }

--- a/tests/generated/flex_direction_row.rs
+++ b/tests/generated/flex_direction_row.rs
@@ -1,39 +1,39 @@
 #[test]
 fn flex_direction_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,21 +41,21 @@ fn flex_direction_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_direction_row_no_width.rs
+++ b/tests/generated/flex_direction_row_no_width.rs
@@ -1,57 +1,57 @@
 #[test]
 fn flex_direction_row_no_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_direction_row_reverse.rs
+++ b/tests/generated/flex_direction_row_reverse.rs
@@ -1,40 +1,40 @@
 #[test]
 fn flex_direction_row_reverse() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::RowReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::RowReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn flex_direction_row_reverse() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 90f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 90f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_child.rs
+++ b/tests/generated/flex_grow_child.rs
@@ -1,25 +1,25 @@
 #[test]
 fn flex_grow_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(0f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_flex_basis_percent_min_max.rs
+++ b/tests/generated/flex_grow_flex_basis_percent_min_max.rs
@@ -1,62 +1,56 @@
 #[test]
 fn flex_grow_flex_basis_percent_min_max() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(0f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(120f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(120f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 120f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 120f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_height_maximized.rs
+++ b/tests/generated/flex_grow_height_maximized.rs
@@ -1,36 +1,36 @@
 #[test]
 fn flex_grow_height_maximized() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Points(200f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,13 +38,13 @@ fn flex_grow_height_maximized() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,21 +52,21 @@ fn flex_grow_height_maximized() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 400f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 400f32);
 }

--- a/tests/generated/flex_grow_in_at_most_container.rs
+++ b/tests/generated/flex_grow_in_at_most_container.rs
@@ -1,24 +1,24 @@
 #[test]
 fn flex_grow_in_at_most_container() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0f32),
+                flex_basis: taffy::style::Dimension::Points(0f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,17 +26,17 @@ fn flex_grow_in_at_most_container() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_less_than_factor_one.rs
+++ b/tests/generated/flex_grow_less_than_factor_one.rs
@@ -1,29 +1,29 @@
 #[test]
 fn flex_grow_less_than_factor_one() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0.2f32,
                 flex_shrink: 0f32,
-                flex_basis: sprawl::style::Dimension::Points(40f32),
+                flex_basis: taffy::style::Dimension::Points(40f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, &[])
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_grow: 0.2f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
-    let node2 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, &[])
+    let node2 = taffy
+        .new_node(taffy::style::Style { flex_grow: 0.4f32, flex_shrink: 0f32, ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,21 +31,21 @@ fn flex_grow_less_than_factor_one() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 132f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 92f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 132f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 184f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 224f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 132f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 92f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 132f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 184f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 224f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_root_minimized.rs
+++ b/tests/generated/flex_grow_root_minimized.rs
@@ -1,36 +1,36 @@
 #[test]
 fn flex_grow_root_minimized() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Points(200f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,17 +38,17 @@ fn flex_grow_root_minimized() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -56,21 +56,21 @@ fn flex_grow_root_minimized() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 300f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 300f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 200f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 300f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 300f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 200f32);
 }

--- a/tests/generated/flex_grow_shrink_at_most.rs
+++ b/tests/generated/flex_grow_shrink_at_most.rs
@@ -1,16 +1,15 @@
 #[test]
 fn flex_grow_shrink_at_most() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
-        .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,17 +17,17 @@ fn flex_grow_shrink_at_most() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_to_min.rs
+++ b/tests/generated/flex_grow_to_min.rs
@@ -1,29 +1,28 @@
 #[test]
 fn flex_grow_to_min() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
-        .new_node(sprawl::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[])
-        .unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 =
+        taffy.new_node(taffy::style::Style { flex_grow: 1f32, flex_shrink: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,17 +30,17 @@ fn flex_grow_to_min() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 50f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 50f32);
 }

--- a/tests/generated/flex_grow_within_constrained_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_max_column.rs
@@ -1,32 +1,32 @@
 #[test]
 fn flex_grow_within_constrained_max_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(100f32),
+                flex_basis: taffy::style::Dimension::Points(100f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,17 +34,17 @@ fn flex_grow_within_constrained_max_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 67f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 33f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 67f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 67f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 33f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 67f32);
 }

--- a/tests/generated/flex_grow_within_constrained_max_row.rs
+++ b/tests/generated/flex_grow_within_constrained_max_row.rs
@@ -1,31 +1,31 @@
 #[test]
 fn flex_grow_within_constrained_max_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(100f32),
+                flex_basis: taffy::style::Dimension::Points(100f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,31 +33,31 @@ fn flex_grow_within_constrained_max_row() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 67f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 33f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 67f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 67f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 33f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 67f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_within_constrained_max_width.rs
+++ b/tests/generated/flex_grow_within_constrained_max_width.rs
@@ -1,21 +1,21 @@
 #[test]
 fn flex_grow_within_constrained_max_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(300f32),
+            taffy::style::Style {
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(300f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,13 +23,13 @@ fn flex_grow_within_constrained_max_width() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,17 +37,17 @@ fn flex_grow_within_constrained_max_width() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_within_constrained_min_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_column.rs
@@ -1,22 +1,22 @@
 #[test]
 fn flex_grow_within_constrained_min_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,17 +24,17 @@ fn flex_grow_within_constrained_min_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 50f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 50f32);
 }

--- a/tests/generated/flex_grow_within_constrained_min_max_column.rs
+++ b/tests/generated/flex_grow_within_constrained_min_max_column.rs
@@ -1,21 +1,21 @@
 #[test]
 fn flex_grow_within_constrained_min_max_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,17 +23,17 @@ fn flex_grow_within_constrained_min_max_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_within_constrained_min_row.rs
+++ b/tests/generated/flex_grow_within_constrained_min_row.rs
@@ -1,22 +1,22 @@
 #[test]
 fn flex_grow_within_constrained_min_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,17 +24,17 @@ fn flex_grow_within_constrained_min_row() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_grow_within_max_width.rs
+++ b/tests/generated/flex_grow_within_max_width.rs
@@ -1,21 +1,21 @@
 #[test]
 fn flex_grow_within_max_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -23,13 +23,13 @@ fn flex_grow_within_max_width() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,17 +37,17 @@ fn flex_grow_within_max_width() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_root_ignored.rs
+++ b/tests/generated/flex_root_ignored.rs
@@ -1,36 +1,36 @@
 #[test]
 fn flex_root_ignored() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Points(200f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(500f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,17 +38,17 @@ fn flex_root_ignored() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 300f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 200f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 300f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 200f32);
 }

--- a/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
+++ b/tests/generated/flex_shrink_by_outer_margin_with_max_size.rs
@@ -1,27 +1,27 @@
 #[test]
 fn flex_shrink_by_outer_margin_with_max_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn flex_shrink_by_outer_margin_with_max_size() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 100f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 100f32);
 }

--- a/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
+++ b/tests/generated/flex_shrink_flex_grow_child_flex_shrink_other_child.rs
@@ -1,14 +1,14 @@
 #[test]
 fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,14 +16,14 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,12 +31,12 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,17 +44,17 @@ fn flex_shrink_flex_grow_child_flex_shrink_other_child() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 250f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 250f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 250f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 250f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 250f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 250f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_shrink_flex_grow_row.rs
+++ b/tests/generated/flex_shrink_flex_grow_row.rs
@@ -1,14 +1,14 @@
 #[test]
 fn flex_shrink_flex_grow_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,14 +16,14 @@ fn flex_shrink_flex_grow_row() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0f32,
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,12 +31,12 @@ fn flex_shrink_flex_grow_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -44,17 +44,17 @@ fn flex_shrink_flex_grow_row() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 250f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 250f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 250f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 250f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 250f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 250f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_shrink_to_zero.rs
+++ b/tests/generated/flex_shrink_to_zero.rs
@@ -1,13 +1,13 @@
 #[test]
 fn flex_shrink_to_zero() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn flex_shrink_to_zero() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn flex_shrink_to_zero() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,30 +43,30 @@ fn flex_shrink_to_zero() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(75f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(75f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 75f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 75f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
+++ b/tests/generated/flex_wrap_align_stretch_fits_one_row.rs
@@ -1,31 +1,31 @@
 #[test]
 fn flex_wrap_align_stretch_fits_one_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,17 +33,17 @@ fn flex_wrap_align_stretch_fits_one_row() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
+++ b/tests/generated/flex_wrap_children_with_min_main_overriding_flex_basis.rs
@@ -1,55 +1,49 @@
 #[test]
 fn flex_wrap_children_with_min_main_overriding_flex_basis() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(55f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(55f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(55f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(55f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 55f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 55f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 50f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 55f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 55f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 50f32);
 }

--- a/tests/generated/flex_wrap_wrap_to_child_height.rs
+++ b/tests/generated/flex_wrap_wrap_to_child_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn flex_wrap_wrap_to_child_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,32 +14,32 @@ fn flex_wrap_wrap_to_child_height() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::FlexStart,
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::FlexStart,
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -47,31 +47,31 @@ fn flex_wrap_wrap_to_child_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 100f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 100f32);
 }

--- a/tests/generated/justify_content_column_center.rs
+++ b/tests/generated/justify_content_column_center.rs
@@ -1,41 +1,41 @@
 #[test]
 fn justify_content_column_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,21 +43,21 @@ fn justify_content_column_center() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 35f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 45f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 55f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 35f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 45f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 55f32);
 }

--- a/tests/generated/justify_content_column_flex_end.rs
+++ b/tests/generated/justify_content_column_flex_end.rs
@@ -1,41 +1,41 @@
 #[test]
 fn justify_content_column_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,21 +43,21 @@ fn justify_content_column_flex_end() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 80f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 90f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 80f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 90f32);
 }

--- a/tests/generated/justify_content_column_flex_start.rs
+++ b/tests/generated/justify_content_column_flex_start.rs
@@ -1,40 +1,40 @@
 #[test]
 fn justify_content_column_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn justify_content_column_flex_start() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 20f32);
 }

--- a/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_bottom.rs
@@ -1,30 +1,27 @@
 #[test]
 fn justify_content_column_min_height_and_margin_bottom() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +29,13 @@ fn justify_content_column_min_height_and_margin_bottom() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/justify_content_column_min_height_and_margin_top.rs
+++ b/tests/generated/justify_content_column_min_height_and_margin_top.rs
@@ -1,27 +1,27 @@
 #[test]
 fn justify_content_column_min_height_and_margin_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn justify_content_column_min_height_and_margin_top() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 20f32);
 }

--- a/tests/generated/justify_content_column_space_around.rs
+++ b/tests/generated/justify_content_column_space_around.rs
@@ -1,41 +1,41 @@
 #[test]
 fn justify_content_column_space_around() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::SpaceAround,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::SpaceAround,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,21 +43,21 @@ fn justify_content_column_space_around() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 12f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 45f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 78f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 12f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 45f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 78f32);
 }

--- a/tests/generated/justify_content_column_space_between.rs
+++ b/tests/generated/justify_content_column_space_between.rs
@@ -1,41 +1,41 @@
 #[test]
 fn justify_content_column_space_between() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::SpaceBetween,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::SpaceBetween,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,21 +43,21 @@ fn justify_content_column_space_between() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 45f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 90f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 45f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 90f32);
 }

--- a/tests/generated/justify_content_column_space_evenly.rs
+++ b/tests/generated/justify_content_column_space_evenly.rs
@@ -1,41 +1,41 @@
 #[test]
 fn justify_content_column_space_evenly() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::SpaceEvenly,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::SpaceEvenly,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,21 +43,21 @@ fn justify_content_column_space_evenly() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 18f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 45f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 73f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 18f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 45f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 73f32);
 }

--- a/tests/generated/justify_content_min_max.rs
+++ b/tests/generated/justify_content_min_max.rs
@@ -1,12 +1,12 @@
 #[test]
 fn justify_content_min_max() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(60f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,18 +14,18 @@ fn justify_content_min_max() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn justify_content_min_max() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 20f32);
 }

--- a/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_greater_than_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(300f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(300f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,17 +14,17 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(100f32),
+                    end: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,14 +32,14 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(1000f32),
-                    height: sprawl::style::Dimension::Points(1584f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(1000f32),
+                    height: taffy::style::Dimension::Points(1584f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -47,21 +47,21 @@ fn justify_content_min_width_with_padding_child_width_greater_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 1000f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 1584f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 1000f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 300f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 1000f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 1584f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 1000f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 300f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
+++ b/tests/generated/justify_content_min_width_with_padding_child_width_lower_than_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(199f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(199f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,17 +14,17 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    end: sprawl::style::Dimension::Points(100f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(100f32),
+                    end: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,14 +32,14 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(1080f32),
-                    height: sprawl::style::Dimension::Points(1584f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(1080f32),
+                    height: taffy::style::Dimension::Points(1584f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -47,21 +47,21 @@ fn justify_content_min_width_with_padding_child_width_lower_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 1080f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 1584f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 1080f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 400f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 199f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 101f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 1080f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 1584f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 1080f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 400f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 199f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 101f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_overflow_min_max.rs
+++ b/tests/generated/justify_content_overflow_min_max.rs
@@ -1,13 +1,13 @@
 #[test]
 fn justify_content_overflow_min_max() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn justify_content_overflow_min_max() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn justify_content_overflow_min_max() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,17 +43,17 @@ fn justify_content_overflow_min_max() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(110f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(110f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -61,21 +61,21 @@ fn justify_content_overflow_min_max() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 110f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, -20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 110f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, -20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 80f32);
 }

--- a/tests/generated/justify_content_row_center.rs
+++ b/tests/generated/justify_content_row_center.rs
@@ -1,40 +1,40 @@
 #[test]
 fn justify_content_row_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn justify_content_row_center() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 35f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 45f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 55f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 35f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 45f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 55f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_flex_end.rs
+++ b/tests/generated/justify_content_row_flex_end.rs
@@ -1,40 +1,40 @@
 #[test]
 fn justify_content_row_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn justify_content_row_flex_end() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 90f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 90f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_flex_start.rs
+++ b/tests/generated/justify_content_row_flex_start.rs
@@ -1,39 +1,39 @@
 #[test]
 fn justify_content_row_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,21 +41,21 @@ fn justify_content_row_flex_start() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_max_width_and_margin.rs
+++ b/tests/generated/justify_content_row_max_width_and_margin.rs
@@ -1,44 +1,38 @@
 #[test]
 fn justify_content_row_max_width_and_margin() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(100f32),
-                    ..Default::default()
-                },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(80f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 90f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 90f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_min_width_and_margin.rs
+++ b/tests/generated/justify_content_row_min_width_and_margin.rs
@@ -1,40 +1,37 @@
 #[test]
 fn justify_content_row_min_width_and_margin() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_space_around.rs
+++ b/tests/generated/justify_content_row_space_around.rs
@@ -1,40 +1,40 @@
 #[test]
 fn justify_content_row_space_around() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::SpaceAround,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::SpaceAround,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn justify_content_row_space_around() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 12f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 45f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 78f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 12f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 45f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 78f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_space_between.rs
+++ b/tests/generated/justify_content_row_space_between.rs
@@ -1,40 +1,40 @@
 #[test]
 fn justify_content_row_space_between() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::SpaceBetween,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::SpaceBetween,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn justify_content_row_space_between() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 45f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 90f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 45f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 90f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/justify_content_row_space_evenly.rs
+++ b/tests/generated/justify_content_row_space_evenly.rs
@@ -1,40 +1,40 @@
 #[test]
 fn justify_content_row_space_evenly() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::SpaceEvenly,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::SpaceEvenly,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,21 +42,21 @@ fn justify_content_row_space_evenly() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 25f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 75f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 25f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 75f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_and_flex_column.rs
+++ b/tests/generated/margin_and_flex_column.rs
@@ -1,13 +1,13 @@
 #[test]
 fn margin_and_flex_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn margin_and_flex_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn margin_and_flex_column() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/margin_and_flex_row.rs
+++ b/tests/generated/margin_and_flex_row.rs
@@ -1,13 +1,13 @@
 #[test]
 fn margin_and_flex_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ fn margin_and_flex_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn margin_and_flex_row() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_and_stretch_column.rs
+++ b/tests/generated/margin_and_stretch_column.rs
@@ -1,13 +1,13 @@
 #[test]
 fn margin_and_stretch_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn margin_and_stretch_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn margin_and_stretch_column() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_and_stretch_row.rs
+++ b/tests/generated/margin_and_stretch_row.rs
@@ -1,13 +1,13 @@
 #[test]
 fn margin_and_stretch_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,12 +15,12 @@ fn margin_and_stretch_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn margin_and_stretch_row() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/margin_auto_bottom.rs
+++ b/tests/generated/margin_auto_bottom.rs
@@ -1,26 +1,26 @@
 #[test]
 fn margin_auto_bottom() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { bottom: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn margin_auto_bottom() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn margin_auto_bottom() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_bottom_and_top.rs
+++ b/tests/generated/margin_auto_bottom_and_top.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_bottom_and_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Auto,
+                    bottom: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +19,26 @@ fn margin_auto_bottom_and_top() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,17 +46,17 @@ fn margin_auto_bottom_and_top() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_bottom_and_top_justify_center.rs
+++ b/tests/generated/margin_auto_bottom_and_top_justify_center.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_bottom_and_top_justify_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Auto,
+                    bottom: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +19,26 @@ fn margin_auto_bottom_and_top_justify_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,17 +46,17 @@ fn margin_auto_bottom_and_top_justify_center() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_auto_left.rs
+++ b/tests/generated/margin_auto_left.rs
@@ -1,26 +1,26 @@
 #[test]
 fn margin_auto_left() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn margin_auto_left() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn margin_auto_left() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_left_and_right.rs
+++ b/tests/generated/margin_auto_left_and_right.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_left_and_right() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,12 +19,25 @@ fn margin_auto_left_and_right() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,17 +45,17 @@ fn margin_auto_left_and_right() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_auto_left_and_right_column.rs
+++ b/tests/generated/margin_auto_left_and_right_column.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_left_and_right_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +19,26 @@ fn margin_auto_left_and_right_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,17 +46,17 @@ fn margin_auto_left_and_right_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_left_and_right_column_and_center.rs
+++ b/tests/generated/margin_auto_left_and_right_column_and_center.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_left_and_right_column_and_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +19,26 @@ fn margin_auto_left_and_right_column_and_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,17 +46,17 @@ fn margin_auto_left_and_right_column_and_center() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_left_and_right_strech.rs
+++ b/tests/generated/margin_auto_left_and_right_strech.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_left_and_right_strech() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,12 +19,25 @@ fn margin_auto_left_and_right_strech() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,17 +45,17 @@ fn margin_auto_left_and_right_strech() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_auto_left_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_child_bigger_than_parent.rs
@@ -1,27 +1,27 @@
 #[test]
 fn margin_auto_left_child_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn margin_auto_left_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 72f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 72f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_fix_right_child_bigger_than_parent.rs
@@ -1,17 +1,17 @@
 #[test]
 fn margin_auto_left_fix_right_child_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Points(10f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,13 +19,13 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn margin_auto_left_fix_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 42f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 72f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 42f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 72f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_auto_left_right_child_bigger_than_parent.rs
@@ -1,17 +1,17 @@
 #[test]
 fn margin_auto_left_right_child_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Auto,
-                    end: sprawl::style::Dimension::Auto,
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Auto,
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,13 +19,13 @@ fn margin_auto_left_right_child_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn margin_auto_left_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 72f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 72f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_auto_left_stretching_child.rs
+++ b/tests/generated/margin_auto_left_stretching_child.rs
@@ -1,24 +1,24 @@
 #[test]
 fn margin_auto_left_stretching_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Auto, ..Default::default() },
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,13 +26,13 @@ fn margin_auto_left_stretching_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,17 +40,17 @@ fn margin_auto_left_stretching_child() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_mutiple_children_column.rs
+++ b/tests/generated/margin_auto_mutiple_children_column.rs
@@ -1,40 +1,40 @@
 #[test]
 fn margin_auto_mutiple_children_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,14 +42,14 @@ fn margin_auto_mutiple_children_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -57,21 +57,21 @@ fn margin_auto_mutiple_children_column() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 75f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 75f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 150f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 75f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 75f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 150f32);
 }

--- a/tests/generated/margin_auto_mutiple_children_row.rs
+++ b/tests/generated/margin_auto_mutiple_children_row.rs
@@ -1,40 +1,40 @@
 #[test]
 fn margin_auto_mutiple_children_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,13 +42,13 @@ fn margin_auto_mutiple_children_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -56,21 +56,21 @@ fn margin_auto_mutiple_children_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_right.rs
+++ b/tests/generated/margin_auto_right.rs
@@ -1,26 +1,26 @@
 #[test]
 fn margin_auto_right() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn margin_auto_right() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn margin_auto_right() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_top.rs
+++ b/tests/generated/margin_auto_top.rs
@@ -1,26 +1,26 @@
 #[test]
 fn margin_auto_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +28,13 @@ fn margin_auto_top() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn margin_auto_top() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_auto_top_and_bottom_strech.rs
+++ b/tests/generated/margin_auto_top_and_bottom_strech.rs
@@ -1,30 +1,17 @@
 #[test]
 fn margin_auto_top_and_bottom_strech() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Auto,
-                    bottom: sprawl::style::Dimension::Auto,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+                margin: taffy::geometry::Rect {
+                    top: taffy::style::Dimension::Auto,
+                    bottom: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +19,26 @@ fn margin_auto_top_and_bottom_strech() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,17 +46,17 @@ fn margin_auto_top_and_bottom_strech() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 150f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 150f32);
 }

--- a/tests/generated/margin_auto_top_stretching_child.rs
+++ b/tests/generated/margin_auto_top_stretching_child.rs
@@ -1,24 +1,24 @@
 #[test]
 fn margin_auto_top_stretching_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Auto, ..Default::default() },
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Auto, ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -26,13 +26,13 @@ fn margin_auto_top_stretching_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,17 +40,17 @@ fn margin_auto_top_stretching_child() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 75f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 75f32);
 }

--- a/tests/generated/margin_bottom.rs
+++ b/tests/generated/margin_bottom.rs
@@ -1,27 +1,24 @@
 #[test]
 fn margin_bottom() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +26,13 @@ fn margin_bottom() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 80f32);
 }

--- a/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
+++ b/tests/generated/margin_fix_left_auto_right_child_bigger_than_parent.rs
@@ -1,17 +1,17 @@
 #[test]
 fn margin_fix_left_auto_right_child_bigger_than_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(72f32),
-                    height: sprawl::style::Dimension::Points(72f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(72f32),
+                    height: taffy::style::Dimension::Points(72f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Auto,
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Auto,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,13 +19,13 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(52f32),
-                    height: sprawl::style::Dimension::Points(52f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(52f32),
+                    height: taffy::style::Dimension::Points(52f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,13 +33,13 @@ fn margin_fix_left_auto_right_child_bigger_than_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 52f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 42f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 72f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 52f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 42f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 72f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_left.rs
+++ b/tests/generated/margin_left.rs
@@ -1,22 +1,22 @@
 #[test]
 fn margin_left() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,13 +24,13 @@ fn margin_left() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_right.rs
+++ b/tests/generated/margin_right.rs
@@ -1,23 +1,23 @@
 #[test]
 fn margin_right() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,13 +25,13 @@ fn margin_right() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_should_not_be_part_of_max_height.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_height.rs
@@ -1,30 +1,30 @@
 #[test]
 fn margin_should_not_be_part_of_max_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(250f32),
-                    height: sprawl::style::Dimension::Points(250f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(250f32),
+                    height: taffy::style::Dimension::Points(250f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +32,13 @@ fn margin_should_not_be_part_of_max_height() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 250f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 250f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 250f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 250f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 20f32);
 }

--- a/tests/generated/margin_should_not_be_part_of_max_width.rs
+++ b/tests/generated/margin_should_not_be_part_of_max_width.rs
@@ -1,30 +1,30 @@
 #[test]
 fn margin_should_not_be_part_of_max_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect { start: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                margin: taffy::geometry::Rect { start: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(250f32),
-                    height: sprawl::style::Dimension::Points(250f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(250f32),
+                    height: taffy::style::Dimension::Points(250f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +32,13 @@ fn margin_should_not_be_part_of_max_width() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 250f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 250f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 250f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 250f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/margin_top.rs
+++ b/tests/generated/margin_top.rs
@@ -1,23 +1,23 @@
 #[test]
 fn margin_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,13 +25,13 @@ fn margin_top() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/margin_with_sibling_column.rs
+++ b/tests/generated/margin_with_sibling_column.rs
@@ -1,27 +1,24 @@
 #[test]
 fn margin_with_sibling_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(10f32),
-                    ..Default::default()
-                },
+                margin: taffy::geometry::Rect { bottom: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,17 +26,17 @@ fn margin_with_sibling_column() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 45f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 45f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 55f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 45f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 45f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 55f32);
 }

--- a/tests/generated/margin_with_sibling_row.rs
+++ b/tests/generated/margin_with_sibling_row.rs
@@ -1,23 +1,23 @@
 #[test]
 fn margin_with_sibling_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -25,17 +25,17 @@ fn margin_with_sibling_row() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 45f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 45f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 55f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 45f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 45f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 55f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/max_height.rs
+++ b/tests/generated/max_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn max_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn max_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ fn max_height() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/max_height_overrides_height.rs
+++ b/tests/generated/max_height_overrides_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn max_height_overrides_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn max_height_overrides_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/max_height_overrides_height_on_root.rs
+++ b/tests/generated/max_height_overrides_height_on_root.rs
@@ -1,12 +1,12 @@
 #[test]
 fn max_height_overrides_height_on_root() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,9 +14,9 @@ fn max_height_overrides_height_on_root() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
 }

--- a/tests/generated/max_width.rs
+++ b/tests/generated/max_width.rs
@@ -1,26 +1,23 @@
 #[test]
 fn max_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    ..Default::default()
-                },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                max_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,13 +25,13 @@ fn max_width() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/max_width_overrides_width.rs
+++ b/tests/generated/max_width_overrides_width.rs
@@ -1,12 +1,12 @@
 #[test]
 fn max_width_overrides_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn max_width_overrides_width() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/max_width_overrides_width_on_root.rs
+++ b/tests/generated/max_width_overrides_width_on_root.rs
@@ -1,12 +1,12 @@
 #[test]
 fn max_width_overrides_width_on_root() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,9 +14,9 @@ fn max_width_overrides_width_on_root() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
 }

--- a/tests/generated/min_height.rs
+++ b/tests/generated/min_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn min_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(60f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(60f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn min_height() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,17 +29,17 @@ fn min_height() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 80f32);
 }

--- a/tests/generated/min_height_overrides_height.rs
+++ b/tests/generated/min_height_overrides_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn min_height_overrides_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn min_height_overrides_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/min_height_overrides_height_on_root.rs
+++ b/tests/generated/min_height_overrides_height_on_root.rs
@@ -1,12 +1,12 @@
 #[test]
 fn min_height_overrides_height_on_root() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,9 +14,9 @@ fn min_height_overrides_height_on_root() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
 }

--- a/tests/generated/min_max_percent_no_width_height.rs
+++ b/tests/generated/min_max_percent_no_width_height.rs
@@ -1,17 +1,17 @@
 #[test]
 fn min_max_percent_no_width_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.1f32),
-                    height: sprawl::style::Dimension::Percent(0.1f32),
+            taffy::style::Style {
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.1f32),
+                    height: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.1f32),
-                    height: sprawl::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.1f32),
+                    height: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,14 +19,14 @@ fn min_max_percent_no_width_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,13 +34,13 @@ fn min_max_percent_no_width_height() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/min_width.rs
+++ b/tests/generated/min_width.rs
@@ -1,26 +1,23 @@
 #[test]
 fn min_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    ..Default::default()
-                },
+                min_size: taffy::geometry::Size { width: taffy::style::Dimension::Points(60f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,17 +25,17 @@ fn min_width() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/min_width_overrides_width.rs
+++ b/tests/generated/min_width_overrides_width.rs
@@ -1,12 +1,12 @@
 #[test]
 fn min_width_overrides_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn min_width_overrides_width() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/min_width_overrides_width_on_root.rs
+++ b/tests/generated/min_width_overrides_width_on_root.rs
@@ -1,12 +1,12 @@
 #[test]
 fn min_width_overrides_width_on_root() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(50f32), ..Default::default() },
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50f32), ..Default::default() },
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,9 +14,9 @@ fn min_width_overrides_width_on_root() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
 }

--- a/tests/generated/nested_overflowing_child.rs
+++ b/tests/generated/nested_overflowing_child.rs
@@ -1,12 +1,12 @@
 #[test]
 fn nested_overflowing_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,13 +14,13 @@ fn nested_overflowing_child() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -28,17 +28,17 @@ fn nested_overflowing_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/nested_overflowing_child_in_constraint_parent.rs
+++ b/tests/generated/nested_overflowing_child_in_constraint_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn nested_overflowing_child_in_constraint_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn nested_overflowing_child_in_constraint_parent() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn nested_overflowing_child_in_constraint_parent() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,17 +40,17 @@ fn nested_overflowing_child_in_constraint_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/overflow_cross_axis.rs
+++ b/tests/generated/overflow_cross_axis.rs
@@ -1,12 +1,12 @@
 #[test]
 fn overflow_cross_axis() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn overflow_cross_axis() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ fn overflow_cross_axis() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/overflow_main_axis.rs
+++ b/tests/generated/overflow_main_axis.rs
@@ -1,22 +1,22 @@
 #[test]
 fn overflow_main_axis() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 0f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -24,13 +24,13 @@ fn overflow_main_axis() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/padding_align_end_child.rs
+++ b/tests/generated/padding_align_end_child.rs
@@ -1,19 +1,19 @@
 #[test]
 fn padding_align_end_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -21,14 +21,14 @@ fn padding_align_end_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                justify_content: sprawl::style::JustifyContent::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::FlexEnd,
+                justify_content: taffy::style::JustifyContent::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,13 +36,13 @@ fn padding_align_end_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 100f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 100f32);
 }

--- a/tests/generated/padding_center_child.rs
+++ b/tests/generated/padding_center_child.rs
@@ -1,12 +1,12 @@
 #[test]
 fn padding_center_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,21 +14,21 @@ fn padding_center_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,13 +36,13 @@ fn padding_center_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 40f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 40f32);
 }

--- a/tests/generated/padding_flex_child.rs
+++ b/tests/generated/padding_flex_child.rs
@@ -1,29 +1,29 @@
 #[test]
 fn padding_flex_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn padding_flex_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/padding_no_child.rs
+++ b/tests/generated/padding_no_child.rs
@@ -1,14 +1,14 @@
 #[test]
 fn padding_no_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,9 +16,9 @@ fn padding_no_child() {
             &[],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
 }

--- a/tests/generated/padding_stretch_child.rs
+++ b/tests/generated/padding_stretch_child.rs
@@ -1,28 +1,28 @@
 #[test]
 fn padding_stretch_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -30,13 +30,13 @@ fn padding_stretch_child() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/parent_wrap_child_size_overflowing_parent.rs
+++ b/tests/generated/parent_wrap_child_size_overflowing_parent.rs
@@ -1,12 +1,12 @@
 #[test]
 fn parent_wrap_child_size_overflowing_parent() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,21 +14,21 @@ fn parent_wrap_child_size_overflowing_parent() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,17 +36,17 @@ fn parent_wrap_child_size_overflowing_parent() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percent_absolute_position.rs
+++ b/tests/generated/percent_absolute_position.rs
@@ -1,35 +1,35 @@
 #[test]
 fn percent_absolute_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(1f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.5f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -37,13 +37,13 @@ fn percent_absolute_position() {
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(60f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(60f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -51,21 +51,21 @@ fn percent_absolute_position() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percent_within_flex_grow.rs
+++ b/tests/generated/percent_within_flex_grow.rs
@@ -1,49 +1,49 @@
 #[test]
 fn percent_within_flex_grow() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(350f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(350f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -51,25 +51,25 @@ fn percent_within_flex_grow() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 350f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 250f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 350f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 250f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_absolute_position.rs
+++ b/tests/generated/percentage_absolute_position.rs
@@ -1,18 +1,18 @@
 #[test]
 fn percentage_absolute_position() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                position_type: sprawl::style::PositionType::Absolute,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                position_type: taffy::style::PositionType::Absolute,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.3f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.3f32),
+                    top: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -20,13 +20,13 @@ fn percentage_absolute_position() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,13 +34,13 @@ fn percentage_absolute_position() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/percentage_container_in_wrapping_container.rs
+++ b/tests/generated/percentage_container_in_wrapping_container.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_container_in_wrapping_container() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn percentage_container_in_wrapping_container() {
             &[],
         )
         .unwrap();
-    let node001 = sprawl
+    let node001 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(50f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(50f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,31 +27,31 @@ fn percentage_container_in_wrapping_container() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(1f32), ..Default::default() },
+            taffy::style::Style {
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(1f32), ..Default::default() },
                 ..Default::default()
             },
             &[node000, node001],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -59,25 +59,25 @@ fn percentage_container_in_wrapping_container() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 75f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node001).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node001).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node001).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node001).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 75f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node001).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node001).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node001).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node001).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_flex_basis.rs
+++ b/tests/generated/percentage_flex_basis.rs
@@ -1,32 +1,32 @@
 #[test]
 fn percentage_flex_basis() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.25f32),
+                flex_basis: taffy::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -34,17 +34,17 @@ fn percentage_flex_basis() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 125f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 75f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 125f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 125f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 75f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 125f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_flex_basis_cross.rs
+++ b/tests/generated/percentage_flex_basis_cross.rs
@@ -1,33 +1,33 @@
 #[test]
 fn percentage_flex_basis_cross() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.5f32),
+                flex_basis: taffy::style::Dimension::Percent(0.5f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.25f32),
+                flex_basis: taffy::style::Dimension::Percent(0.25f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,17 +35,17 @@ fn percentage_flex_basis_cross() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 250f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 150f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 250f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 250f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 150f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 250f32);
 }

--- a/tests/generated/percentage_flex_basis_cross_max_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_height.rs
@@ -1,13 +1,13 @@
 #[test]
 fn percentage_flex_basis_cross_max_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn percentage_flex_basis_cross_max_height() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn percentage_flex_basis_cross_max_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,17 +43,17 @@ fn percentage_flex_basis_cross_max_height() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 240f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 240f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 240f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 240f32);
 }

--- a/tests/generated/percentage_flex_basis_cross_max_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_max_width.rs
@@ -1,13 +1,13 @@
 #[test]
 fn percentage_flex_basis_cross_max_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn percentage_flex_basis_cross_max_width() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn percentage_flex_basis_cross_max_width() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,17 +43,17 @@ fn percentage_flex_basis_cross_max_width() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 120f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 300f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 100f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 120f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 300f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 100f32);
 }

--- a/tests/generated/percentage_flex_basis_cross_min_height.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_flex_basis_cross_min_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.6f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn percentage_flex_basis_cross_min_height() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 2f32,
-                min_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ fn percentage_flex_basis_cross_min_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -41,17 +41,17 @@ fn percentage_flex_basis_cross_min_height() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 280f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 120f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 280f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 280f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 120f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 280f32);
 }

--- a/tests/generated/percentage_flex_basis_cross_min_width.rs
+++ b/tests/generated/percentage_flex_basis_cross_min_width.rs
@@ -1,13 +1,13 @@
 #[test]
 fn percentage_flex_basis_cross_min_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn percentage_flex_basis_cross_min_width() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn percentage_flex_basis_cross_min_width() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -43,17 +43,17 @@ fn percentage_flex_basis_cross_min_width() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 300f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 100f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 300f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 100f32);
 }

--- a/tests/generated/percentage_flex_basis_main_max_height.rs
+++ b/tests/generated/percentage_flex_basis_main_max_height.rs
@@ -1,13 +1,13 @@
 #[test]
 fn percentage_flex_basis_main_max_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn percentage_flex_basis_main_max_height() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,12 +29,12 @@ fn percentage_flex_basis_main_max_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn percentage_flex_basis_main_max_height() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 52f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 240f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 148f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 52f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 52f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 240f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 148f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 52f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_flex_basis_main_max_width.rs
+++ b/tests/generated/percentage_flex_basis_main_max_width.rs
@@ -1,13 +1,13 @@
 #[test]
 fn percentage_flex_basis_main_max_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn percentage_flex_basis_main_max_width() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                max_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                max_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,12 +29,12 @@ fn percentage_flex_basis_main_max_width() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn percentage_flex_basis_main_max_width() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 120f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 120f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 120f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 120f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_flex_basis_main_min_width.rs
+++ b/tests/generated/percentage_flex_basis_main_min_width.rs
@@ -1,13 +1,13 @@
 #[test]
 fn percentage_flex_basis_main_min_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -15,13 +15,13 @@ fn percentage_flex_basis_main_min_width() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,12 +29,12 @@ fn percentage_flex_basis_main_min_width() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -42,17 +42,17 @@ fn percentage_flex_basis_main_min_width() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 120f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 120f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 120f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 120f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_margin_should_calculate_based_only_on_width.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_margin_should_calculate_based_only_on_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,16 +14,16 @@ fn percentage_margin_should_calculate_based_only_on_width() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.1f32),
+                    end: taffy::style::Dimension::Percent(0.1f32),
+                    top: taffy::style::Dimension::Percent(0.1f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn percentage_margin_should_calculate_based_only_on_width() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,17 +45,17 @@ fn percentage_margin_should_calculate_based_only_on_width() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 160f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 160f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
+++ b/tests/generated/percentage_multiple_nested_with_padding_margin_and_percentage_values.rs
@@ -1,25 +1,22 @@
 #[test]
 fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.45f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.45f32), ..Default::default() },
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.05f32),
+                    end: taffy::style::Dimension::Percent(0.05f32),
+                    top: taffy::style::Dimension::Percent(0.05f32),
+                    bottom: taffy::style::Dimension::Percent(0.05f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.05f32),
-                    end: sprawl::style::Dimension::Percent(0.05f32),
-                    top: sprawl::style::Dimension::Percent(0.05f32),
-                    bottom: sprawl::style::Dimension::Percent(0.05f32),
-                    ..Default::default()
-                },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(3f32),
+                    end: taffy::style::Dimension::Points(3f32),
+                    top: taffy::style::Dimension::Points(3f32),
+                    bottom: taffy::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,23 +24,23 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Percent(0.5f32), ..Default::default() },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Percent(0.5f32), ..Default::default() },
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(5f32),
+                    end: taffy::style::Dimension::Points(5f32),
+                    top: taffy::style::Dimension::Points(5f32),
+                    bottom: taffy::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.03f32),
-                    end: sprawl::style::Dimension::Percent(0.03f32),
-                    top: sprawl::style::Dimension::Percent(0.03f32),
-                    bottom: sprawl::style::Dimension::Percent(0.03f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.03f32),
+                    end: taffy::style::Dimension::Percent(0.03f32),
+                    top: taffy::style::Dimension::Percent(0.03f32),
+                    bottom: taffy::style::Dimension::Percent(0.03f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -51,28 +48,28 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[node000],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.1f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.6f32),
+                flex_basis: taffy::style::Dimension::Percent(0.1f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.6f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(5f32),
-                    end: sprawl::style::Dimension::Points(5f32),
-                    top: sprawl::style::Dimension::Points(5f32),
-                    bottom: sprawl::style::Dimension::Points(5f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(5f32),
+                    end: taffy::style::Dimension::Points(5f32),
+                    top: taffy::style::Dimension::Points(5f32),
+                    bottom: taffy::style::Dimension::Points(5f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(3f32),
-                    end: sprawl::style::Dimension::Points(3f32),
-                    top: sprawl::style::Dimension::Points(3f32),
-                    bottom: sprawl::style::Dimension::Points(3f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(3f32),
+                    end: taffy::style::Dimension::Points(3f32),
+                    top: taffy::style::Dimension::Points(3f32),
+                    bottom: taffy::style::Dimension::Points(3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -80,13 +77,13 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[node00],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Percent(0.15f32),
-                min_size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.2f32),
+                flex_basis: taffy::style::Dimension::Percent(0.15f32),
+                min_size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -94,13 +91,13 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -108,25 +105,25 @@ fn percentage_multiple_nested_with_padding_margin_and_percentage_values() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 190f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 48f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 5f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 5f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 92f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 8f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 8f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 36f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 6f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 142f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 58f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 190f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 48f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 5f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 5f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 92f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 8f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 8f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 36f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 6f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 142f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 58f32);
 }

--- a/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
+++ b/tests/generated/percentage_padding_should_calculate_based_only_on_width.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_padding_should_calculate_based_only_on_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,16 +14,16 @@ fn percentage_padding_should_calculate_based_only_on_width() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    end: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.1f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.1f32),
+                    end: taffy::style::Dimension::Percent(0.1f32),
+                    top: taffy::style::Dimension::Percent(0.1f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -31,13 +31,13 @@ fn percentage_padding_should_calculate_based_only_on_width() {
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -45,17 +45,17 @@ fn percentage_padding_should_calculate_based_only_on_width() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 20f32);
 }

--- a/tests/generated/percentage_position_bottom_right.rs
+++ b/tests/generated/percentage_position_bottom_right.rs
@@ -1,17 +1,17 @@
 #[test]
 fn percentage_position_bottom_right() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.55f32),
-                    height: sprawl::style::Dimension::Percent(0.15f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.55f32),
+                    height: taffy::style::Dimension::Percent(0.15f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    end: sprawl::style::Dimension::Percent(0.2f32),
-                    bottom: sprawl::style::Dimension::Percent(0.1f32),
+                position: taffy::geometry::Rect {
+                    end: taffy::style::Dimension::Percent(0.2f32),
+                    bottom: taffy::style::Dimension::Percent(0.1f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,12 +19,12 @@ fn percentage_position_bottom_right() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +32,13 @@ fn percentage_position_bottom_right() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 275f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 75f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, -100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, -50f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 275f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 75f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, -100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, -50f32);
 }

--- a/tests/generated/percentage_position_left_top.rs
+++ b/tests/generated/percentage_position_left_top.rs
@@ -1,17 +1,17 @@
 #[test]
 fn percentage_position_left_top() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.45f32),
-                    height: sprawl::style::Dimension::Percent(0.55f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.45f32),
+                    height: taffy::style::Dimension::Percent(0.55f32),
                     ..Default::default()
                 },
-                position: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Percent(0.1f32),
-                    top: sprawl::style::Dimension::Percent(0.2f32),
+                position: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Percent(0.1f32),
+                    top: taffy::style::Dimension::Percent(0.2f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,12 +19,12 @@ fn percentage_position_left_top() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(400f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(400f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -32,13 +32,13 @@ fn percentage_position_left_top() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 180f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 220f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 40f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 180f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 220f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 40f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 80f32);
 }

--- a/tests/generated/percentage_size_based_on_parent_inner_size.rs
+++ b/tests/generated/percentage_size_based_on_parent_inner_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_size_based_on_parent_inner_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.5f32),
-                    height: sprawl::style::Dimension::Percent(0.5f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.5f32),
+                    height: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,20 +14,20 @@ fn percentage_size_based_on_parent_inner_size() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,13 +35,13 @@ fn percentage_size_based_on_parent_inner_size() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 180f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 20f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 180f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 20f32);
 }

--- a/tests/generated/percentage_size_of_flex_basis.rs
+++ b/tests/generated/percentage_size_of_flex_basis.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_size_of_flex_basis() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(1f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(1f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,32 +14,32 @@ fn percentage_size_of_flex_basis() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(50f32), ..Default::default() },
+            taffy::style::Style { flex_basis: taffy::style::Dimension::Points(50f32), ..Default::default() },
             &[node00],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_width_height.rs
+++ b/tests/generated/percentage_width_height.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_width_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.3f32),
-                    height: sprawl::style::Dimension::Percent(0.3f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.3f32),
+                    height: taffy::style::Dimension::Percent(0.3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn percentage_width_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(400f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(400f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,13 +27,13 @@ fn percentage_width_height() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 400f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 60f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 120f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 400f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 60f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 120f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/percentage_width_height_undefined_parent_size.rs
+++ b/tests/generated/percentage_width_height_undefined_parent_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn percentage_width_height_undefined_parent_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Percent(0.5f32),
-                    height: sprawl::style::Dimension::Percent(0.5f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Percent(0.5f32),
+                    height: taffy::style::Dimension::Percent(0.5f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,19 +14,19 @@ fn percentage_width_height_undefined_parent_size() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/relative_position_should_not_nudge_siblings.rs
+++ b/tests/generated/relative_position_should_not_nudge_siblings.rs
@@ -1,33 +1,33 @@
 #[test]
 fn relative_position_should_not_nudge_siblings() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(15f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
-                position: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(15f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(15f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -35,17 +35,17 @@ fn relative_position_should_not_nudge_siblings() {
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 15f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 25f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 15f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 25f32);
 }

--- a/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_prime_number_width.rs
@@ -1,17 +1,17 @@
 #[test]
 fn rounding_flex_basis_flex_grow_row_prime_number_width() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node2 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node3 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node4 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node3 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node4 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(113f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(113f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -19,29 +19,29 @@ fn rounding_flex_basis_flex_grow_row_prime_number_width() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 23f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 22f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 23f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 23f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 45f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 22f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 68f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 23f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 90f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 23f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 22f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 23f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 23f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 45f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 22f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 68f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 23f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 90f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
+++ b/tests/generated/rounding_flex_basis_flex_grow_row_width_of_100.rs
@@ -1,15 +1,15 @@
 #[test]
 fn rounding_flex_basis_flex_grow_row_width_of_100() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node1 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node2 = sprawl.new_node(sprawl::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
-    let node = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node1 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node2 = taffy.new_node(taffy::style::Style { flex_grow: 1f32, ..Default::default() }, &[]).unwrap();
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -17,21 +17,21 @@ fn rounding_flex_basis_flex_grow_row_width_of_100() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 33f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 34f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 33f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 33f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 67f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 33f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 34f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 33f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 33f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 67f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/rounding_flex_basis_flex_shrink_row.rs
+++ b/tests/generated/rounding_flex_basis_flex_shrink_row.rs
@@ -1,34 +1,28 @@
 #[test]
 fn rounding_flex_basis_flex_shrink_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(100f32),
+                flex_basis: taffy::style::Dimension::Points(100f32),
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(25f32), ..Default::default() },
-            &[],
-        )
+    let node1 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(25f32), ..Default::default() }, &[])
         .unwrap();
-    let node2 = sprawl
-        .new_node(
-            sprawl::style::Style { flex_basis: sprawl::style::Dimension::Points(25f32), ..Default::default() },
-            &[],
-        )
+    let node2 = taffy
+        .new_node(taffy::style::Style { flex_basis: taffy::style::Dimension::Points(25f32), ..Default::default() }, &[])
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(101f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(101f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -36,21 +30,21 @@ fn rounding_flex_basis_flex_shrink_row() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 101f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 67f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 17f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 67f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 17f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 84f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 101f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 67f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 17f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 67f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 17f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 84f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
 }

--- a/tests/generated/rounding_flex_basis_overrides_main_size.rs
+++ b/tests/generated/rounding_flex_basis_overrides_main_size.rs
@@ -1,44 +1,44 @@
 #[test]
 fn rounding_flex_basis_overrides_main_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,21 +46,21 @@ fn rounding_flex_basis_overrides_main_size() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 64f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 64f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 64f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 64f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/rounding_fractial_input_1.rs
+++ b/tests/generated/rounding_fractial_input_1.rs
@@ -1,44 +1,44 @@
 #[test]
 fn rounding_fractial_input_1() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,21 +46,21 @@ fn rounding_fractial_input_1() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 64f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 64f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 64f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 64f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/rounding_fractial_input_2.rs
+++ b/tests/generated/rounding_fractial_input_2.rs
@@ -1,44 +1,44 @@
 #[test]
 fn rounding_fractial_input_2() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.6f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.6f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,21 +46,21 @@ fn rounding_fractial_input_2() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 114f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 65f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 65f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 114f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 65f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 65f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/rounding_fractial_input_3.rs
+++ b/tests/generated/rounding_fractial_input_3.rs
@@ -1,44 +1,44 @@
 #[test]
 fn rounding_fractial_input_3() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,21 +46,21 @@ fn rounding_fractial_input_3() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 64f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 64f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 64f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 64f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/rounding_fractial_input_4.rs
+++ b/tests/generated/rounding_fractial_input_4.rs
@@ -1,44 +1,44 @@
 #[test]
 fn rounding_fractial_input_4() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(50f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(20f32), ..Default::default() },
+                flex_basis: taffy::style::Dimension::Points(50f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -46,21 +46,21 @@ fn rounding_fractial_input_4() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 64f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 64f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 64f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 64f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/rounding_total_fractial.rs
+++ b/tests/generated/rounding_total_fractial.rs
@@ -1,50 +1,44 @@
 #[test]
 fn rounding_total_fractial() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 0.7f32,
-                flex_basis: sprawl::style::Dimension::Points(50.3f32),
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(20.3f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(50.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20.3f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.6f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.1f32,
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(10.7f32),
-                    ..Default::default()
-                },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10.7f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(87.4f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(87.4f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -52,21 +46,21 @@ fn rounding_total_fractial() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 59f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 59f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 59f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 59f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/rounding_total_fractial_nested.rs
+++ b/tests/generated/rounding_total_fractial_nested.rs
@@ -1,14 +1,14 @@
 #[test]
 fn rounding_total_fractial_nested() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
-                flex_basis: sprawl::style::Dimension::Points(0.3f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(9.9f32), ..Default::default() },
-                position: sprawl::geometry::Rect {
-                    bottom: sprawl::style::Dimension::Points(13.3f32),
+                flex_basis: taffy::style::Dimension::Points(0.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(9.9f32), ..Default::default() },
+                position: taffy::geometry::Rect {
+                    bottom: taffy::style::Dimension::Points(13.3f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -16,66 +16,57 @@ fn rounding_total_fractial_nested() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 4f32,
-                flex_basis: sprawl::style::Dimension::Points(0.3f32),
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(1.1f32), ..Default::default() },
-                position: sprawl::geometry::Rect {
-                    top: sprawl::style::Dimension::Points(13.3f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(0.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(1.1f32), ..Default::default() },
+                position: taffy::geometry::Rect { top: taffy::style::Dimension::Points(13.3f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 0.7f32,
-                flex_basis: sprawl::style::Dimension::Points(50.3f32),
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(20.3f32),
-                    ..Default::default()
-                },
+                flex_basis: taffy::style::Dimension::Points(50.3f32),
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(20.3f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00, node01],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.6f32,
-                size: sprawl::geometry::Size { height: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1.1f32,
-                size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(10.7f32),
-                    ..Default::default()
-                },
+                size: taffy::geometry::Size { height: taffy::style::Dimension::Points(10.7f32), ..Default::default() },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(87.4f32),
-                    height: sprawl::style::Dimension::Points(113.4f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(87.4f32),
+                    height: taffy::style::Dimension::Points(113.4f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -83,29 +74,29 @@ fn rounding_total_fractial_nested() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 113f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 59f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 12f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, -13f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 47f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 25f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 59f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 87f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 24f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 89f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 113f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 59f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 12f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, -13f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 47f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 25f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 59f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 87f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 24f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 89f32);
 }

--- a/tests/generated/size_defined_by_child.rs
+++ b/tests/generated/size_defined_by_child.rs
@@ -1,12 +1,12 @@
 #[test]
 fn size_defined_by_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn size_defined_by_child() {
             &[],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
 }

--- a/tests/generated/size_defined_by_child_with_border.rs
+++ b/tests/generated/size_defined_by_child_with_border.rs
@@ -1,12 +1,12 @@
 #[test]
 fn size_defined_by_child_with_border() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn size_defined_by_child_with_border() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                border: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                border: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn size_defined_by_child_with_border() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/size_defined_by_child_with_padding.rs
+++ b/tests/generated/size_defined_by_child_with_padding.rs
@@ -1,12 +1,12 @@
 #[test]
 fn size_defined_by_child_with_padding() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(10f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(10f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,14 +14,14 @@ fn size_defined_by_child_with_padding() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                padding: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(10f32),
-                    end: sprawl::style::Dimension::Points(10f32),
-                    top: sprawl::style::Dimension::Points(10f32),
-                    bottom: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                padding: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(10f32),
+                    end: taffy::style::Dimension::Points(10f32),
+                    top: taffy::style::Dimension::Points(10f32),
+                    bottom: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -29,13 +29,13 @@ fn size_defined_by_child_with_padding() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
 }

--- a/tests/generated/size_defined_by_grand_child.rs
+++ b/tests/generated/size_defined_by_grand_child.rs
@@ -1,12 +1,12 @@
 #[test]
 fn size_defined_by_grand_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,19 +14,19 @@ fn size_defined_by_grand_child() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node00]).unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
+    let node0 = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node00]).unwrap();
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
 }

--- a/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_large_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_large_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn width_smaller_then_content_with_flex_grow_large_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_small_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_small_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn width_smaller_then_content_with_flex_grow_small_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 10f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 5f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 5f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 5f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 10f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 5f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 5f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 5f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_unconstraint_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,37 +38,37 @@ fn width_smaller_then_content_with_flex_grow_unconstraint_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[node0, node1]).unwrap();
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
+++ b/tests/generated/width_smaller_then_content_with_flex_grow_very_large_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn width_smaller_then_content_with_flex_grow_very_large_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(70f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(70f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,23 +14,23 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00],
         )
         .unwrap();
-    let node10 = sprawl
+    let node10 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(20f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(20f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -38,45 +38,45 @@ fn width_smaller_then_content_with_flex_grow_very_large_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
                 flex_grow: 1f32,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(0f32), ..Default::default() },
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(0f32), ..Default::default() },
                 ..Default::default()
             },
             &[node10],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(200f32), ..Default::default() },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(200f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 100f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.width, 20f32);
-    assert_eq!(sprawl.layout(node10).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node10).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 100f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.width, 20f32);
+    assert_eq!(taffy.layout(node10).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node10).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_column.rs
+++ b/tests/generated/wrap_column.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(31f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(31f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_column() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(32f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(32f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_column() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(33f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(33f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_column() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(34f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(34f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,14 +53,14 @@ fn wrap_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -68,25 +68,25 @@ fn wrap_column() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 31f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 32f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 31f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 33f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 63f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 34f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 31f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 32f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 31f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 33f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 63f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 34f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_margin_cross.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_nodes_with_content_sizing_margin_cross() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,18 +14,18 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node000],
         )
         .unwrap();
-    let node010 = sprawl
+    let node010 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,33 +33,33 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { top: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                margin: taffy::geometry::Rect { top: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node010],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(70f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(70f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -67,29 +67,29 @@ fn wrap_nodes_with_content_sizing_margin_cross() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 90f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 50f32);
-    assert_eq!(sprawl.layout(node010).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node010).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node010).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node010).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 90f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 50f32);
+    assert_eq!(taffy.layout(node010).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node010).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node010).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node010).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
+++ b/tests/generated/wrap_nodes_with_content_sizing_overflowing_margin.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_nodes_with_content_sizing_overflowing_margin() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node000 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node000 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,18 +14,18 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
             &[],
         )
         .unwrap();
-    let node00 = sprawl
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style { flex_direction: sprawl::style::FlexDirection::Column, ..Default::default() },
+            taffy::style::Style { flex_direction: taffy::style::FlexDirection::Column, ..Default::default() },
             &[node000],
         )
         .unwrap();
-    let node010 = sprawl
+    let node010 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(40f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(40f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -33,33 +33,33 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                margin: sprawl::geometry::Rect { end: sprawl::style::Dimension::Points(10f32), ..Default::default() },
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                margin: taffy::geometry::Rect { end: taffy::style::Dimension::Points(10f32), ..Default::default() },
                 ..Default::default()
             },
             &[node010],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(85f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(85f32), ..Default::default() },
                 ..Default::default()
             },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(500f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(500f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -67,29 +67,29 @@ fn wrap_nodes_with_content_sizing_overflowing_margin() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 85f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node000).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node000).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node010).unwrap().size.width, 40f32);
-    assert_eq!(sprawl.layout(node010).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node010).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node010).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 85f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node000).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node000).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node010).unwrap().size.width, 40f32);
+    assert_eq!(taffy.layout(node010).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node010).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node010).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_column.rs
+++ b/tests/generated/wrap_reverse_column.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_column() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(31f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(31f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_column() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(32f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(32f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_column() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(33f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(33f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_column() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(34f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(34f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,14 +53,14 @@ fn wrap_reverse_column() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -68,25 +68,25 @@ fn wrap_reverse_column() {
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 31f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 32f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 31f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 33f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 70f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 63f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 34f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 20f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 31f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 32f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 31f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 33f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 70f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 63f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 34f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 20f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_column_fixed_size.rs
+++ b/tests/generated/wrap_reverse_column_fixed_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_column_fixed_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_column_fixed_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_column_fixed_size() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_column_fixed_size() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn wrap_reverse_column_fixed_size() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,15 +66,15 @@ fn wrap_reverse_column_fixed_size() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(100f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -82,29 +82,29 @@ fn wrap_reverse_column_fixed_size() {
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 135f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 135f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 135f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 135f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 60f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 35f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 135f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 135f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 135f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 135f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 60f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 35f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_row.rs
+++ b/tests/generated/wrap_reverse_row.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(31f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(31f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_row() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(32f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(32f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_row() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(33f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(33f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_row() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(34f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(34f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,35 +53,35 @@ fn wrap_reverse_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 31f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 32f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 31f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 33f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 63f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 34f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 31f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 32f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 31f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 33f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 63f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 34f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_row_align_content_center.rs
+++ b/tests/generated/wrap_reverse_row_align_content_center.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_row_align_content_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_row_align_content_center() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_row_align_content_center() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_row_align_content_center() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn wrap_reverse_row_align_content_center() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,40 +66,40 @@ fn wrap_reverse_row_align_content_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_row_align_content_flex_start.rs
+++ b/tests/generated/wrap_reverse_row_align_content_flex_start.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_row_align_content_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,40 +66,40 @@ fn wrap_reverse_row_align_content_flex_start() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::FlexStart,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::FlexStart,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_row_align_content_space_around.rs
+++ b/tests/generated/wrap_reverse_row_align_content_space_around.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_row_align_content_space_around() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_row_align_content_space_around() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_row_align_content_space_around() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_row_align_content_space_around() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn wrap_reverse_row_align_content_space_around() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,40 +66,40 @@ fn wrap_reverse_row_align_content_space_around() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::SpaceAround,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::SpaceAround,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_row_align_content_stretch.rs
+++ b/tests/generated/wrap_reverse_row_align_content_stretch.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_row_align_content_stretch() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_row_align_content_stretch() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_row_align_content_stretch() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_row_align_content_stretch() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn wrap_reverse_row_align_content_stretch() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,39 +66,39 @@ fn wrap_reverse_row_align_content_stretch() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 70f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 50f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 70f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 50f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_reverse_row_single_line_different_size.rs
+++ b/tests/generated/wrap_reverse_row_single_line_different_size.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_reverse_row_single_line_different_size() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_reverse_row_single_line_different_size() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_reverse_row_single_line_different_size() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_reverse_row_single_line_different_size() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(40f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(40f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,12 +53,12 @@ fn wrap_reverse_row_single_line_different_size() {
             &[],
         )
         .unwrap();
-    let node4 = sprawl
+    let node4 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(50f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(50f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -66,40 +66,40 @@ fn wrap_reverse_row_single_line_different_size() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::WrapReverse,
-                align_content: sprawl::style::AlignContent::FlexStart,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(300f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::WrapReverse,
+                align_content: taffy::style::AlignContent::FlexStart,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(300f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3, node4],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 300f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 40f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 20f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 40f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 90f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node4).unwrap().size.height, 50f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.x, 120f32);
-    assert_eq!(sprawl.layout(node4).unwrap().location.y, 0f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 300f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 40f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 20f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 40f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 90f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node4).unwrap().size.height, 50f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.x, 120f32);
+    assert_eq!(taffy.layout(node4).unwrap().location.y, 0f32);
 }

--- a/tests/generated/wrap_row.rs
+++ b/tests/generated/wrap_row.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_row() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(31f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(31f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_row() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(32f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(32f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_row() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(33f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(33f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_row() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(34f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(34f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,35 +53,35 @@ fn wrap_row() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 31f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 32f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 31f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 33f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 63f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 34f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 31f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 32f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 31f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 33f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 63f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 34f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 30f32);
 }

--- a/tests/generated/wrap_row_align_items_center.rs
+++ b/tests/generated/wrap_row_align_items_center.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_row_align_items_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_row_align_items_center() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_row_align_items_center() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_row_align_items_center() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,36 +53,36 @@ fn wrap_row_align_items_center() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 5f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 5f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 30f32);
 }

--- a/tests/generated/wrap_row_align_items_flex_end.rs
+++ b/tests/generated/wrap_row_align_items_flex_end.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrap_row_align_items_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(10f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(10f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrap_row_align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(20f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,12 +27,12 @@ fn wrap_row_align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node2 = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -40,12 +40,12 @@ fn wrap_row_align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node3 = sprawl
+    let node3 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(30f32),
-                    height: sprawl::style::Dimension::Points(30f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(30f32),
+                    height: taffy::style::Dimension::Points(30f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -53,36 +53,36 @@ fn wrap_row_align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                size: sprawl::geometry::Size { width: sprawl::style::Dimension::Points(100f32), ..Default::default() },
+            taffy::style::Style {
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::FlexEnd,
+                size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100f32), ..Default::default() },
                 ..Default::default()
             },
             &[node0, node1, node2, node3],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 60f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 10f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 20f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 10f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 60f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.width, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().size.height, 30f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node3).unwrap().location.y, 30f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 60f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 10f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 20f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 10f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 60f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.width, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().size.height, 30f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node3).unwrap().location.y, 30f32);
 }

--- a/tests/generated/wrapped_column_max_height.rs
+++ b/tests/generated/wrapped_column_max_height.rs
@@ -1,16 +1,16 @@
 #[test]
 fn wrapped_column_max_height() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -18,32 +18,19 @@ fn wrapped_column_max_height() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node2 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -51,17 +38,30 @@ fn wrapped_column_max_height() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::Center,
-                align_content: sprawl::style::AlignContent::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(700f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::Center,
+                align_content: taffy::style::AlignContent::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(700f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -69,21 +69,21 @@ fn wrapped_column_max_height() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 700f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 250f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 30f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 250f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 420f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 200f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 700f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 250f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 30f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 250f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 420f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 200f32);
 }

--- a/tests/generated/wrapped_column_max_height_flex.rs
+++ b/tests/generated/wrapped_column_max_height_flex.rs
@@ -1,19 +1,19 @@
 #[test]
 fn wrapped_column_max_height_flex() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
-                max_size: sprawl::geometry::Size {
-                    height: sprawl::style::Dimension::Points(200f32),
+                max_size: taffy::geometry::Size {
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -21,35 +21,22 @@ fn wrapped_column_max_height_flex() {
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
+            taffy::style::Style {
                 flex_grow: 1f32,
                 flex_shrink: 1f32,
-                flex_basis: sprawl::style::Dimension::Percent(0f32),
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+                flex_basis: taffy::style::Dimension::Percent(0f32),
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
-                margin: sprawl::geometry::Rect {
-                    start: sprawl::style::Dimension::Points(20f32),
-                    end: sprawl::style::Dimension::Points(20f32),
-                    top: sprawl::style::Dimension::Points(20f32),
-                    bottom: sprawl::style::Dimension::Points(20f32),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            &[],
-        )
-        .unwrap();
-    let node2 = sprawl
-        .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(100f32),
-                    height: sprawl::style::Dimension::Points(100f32),
+                margin: taffy::geometry::Rect {
+                    start: taffy::style::Dimension::Points(20f32),
+                    end: taffy::style::Dimension::Points(20f32),
+                    top: taffy::style::Dimension::Points(20f32),
+                    bottom: taffy::style::Dimension::Points(20f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -57,17 +44,30 @@ fn wrapped_column_max_height_flex() {
             &[],
         )
         .unwrap();
-    let node = sprawl
+    let node2 = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                flex_wrap: sprawl::style::FlexWrap::Wrap,
-                align_items: sprawl::style::AlignItems::Center,
-                align_content: sprawl::style::AlignContent::Center,
-                justify_content: sprawl::style::JustifyContent::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(700f32),
-                    height: sprawl::style::Dimension::Points(500f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(100f32),
+                    height: taffy::style::Dimension::Points(100f32),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+    let node = taffy
+        .new_node(
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                flex_wrap: taffy::style::FlexWrap::Wrap,
+                align_items: taffy::style::AlignItems::Center,
+                align_content: taffy::style::AlignContent::Center,
+                justify_content: taffy::style::JustifyContent::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(700f32),
+                    height: taffy::style::Dimension::Points(500f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -75,21 +75,21 @@ fn wrapped_column_max_height_flex() {
             &[node0, node1, node2],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 700f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 500f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 180f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 300f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node1).unwrap().size.height, 180f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.x, 250f32);
-    assert_eq!(sprawl.layout(node1).unwrap().location.y, 200f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.width, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().size.height, 100f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.x, 300f32);
-    assert_eq!(sprawl.layout(node2).unwrap().location.y, 400f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 700f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 500f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 180f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 300f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node1).unwrap().size.height, 180f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.x, 250f32);
+    assert_eq!(taffy.layout(node1).unwrap().location.y, 200f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.width, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().size.height, 100f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.x, 300f32);
+    assert_eq!(taffy.layout(node2).unwrap().location.y, 400f32);
 }

--- a/tests/generated/wrapped_row_within_align_items_center.rs
+++ b/tests/generated/wrapped_row_within_align_items_center.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrapped_row_within_align_items_center() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrapped_row_within_align_items_center() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(80f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,20 +27,20 @@ fn wrapped_row_within_align_items_center() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_wrap: sprawl::style::FlexWrap::Wrap, ..Default::default() },
+            taffy::style::Style { flex_wrap: taffy::style::FlexWrap::Wrap, ..Default::default() },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::Center,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::Center,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -48,21 +48,21 @@ fn wrapped_row_within_align_items_center() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 160f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 160f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 80f32);
 }

--- a/tests/generated/wrapped_row_within_align_items_flex_end.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_end.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrapped_row_within_align_items_flex_end() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrapped_row_within_align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(80f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,20 +27,20 @@ fn wrapped_row_within_align_items_flex_end() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_wrap: sprawl::style::FlexWrap::Wrap, ..Default::default() },
+            taffy::style::Style { flex_wrap: taffy::style::FlexWrap::Wrap, ..Default::default() },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::FlexEnd,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::FlexEnd,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -48,21 +48,21 @@ fn wrapped_row_within_align_items_flex_end() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 160f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 160f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 80f32);
 }

--- a/tests/generated/wrapped_row_within_align_items_flex_start.rs
+++ b/tests/generated/wrapped_row_within_align_items_flex_start.rs
@@ -1,12 +1,12 @@
 #[test]
 fn wrapped_row_within_align_items_flex_start() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node00 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node00 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(150f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(150f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -14,12 +14,12 @@ fn wrapped_row_within_align_items_flex_start() {
             &[],
         )
         .unwrap();
-    let node01 = sprawl
+    let node01 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(80f32),
-                    height: sprawl::style::Dimension::Points(80f32),
+            taffy::style::Style {
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(80f32),
+                    height: taffy::style::Dimension::Points(80f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -27,20 +27,20 @@ fn wrapped_row_within_align_items_flex_start() {
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style { flex_wrap: sprawl::style::FlexWrap::Wrap, ..Default::default() },
+            taffy::style::Style { flex_wrap: taffy::style::FlexWrap::Wrap, ..Default::default() },
             &[node00, node01],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                flex_direction: sprawl::style::FlexDirection::Column,
-                align_items: sprawl::style::AlignItems::FlexStart,
-                size: sprawl::geometry::Size {
-                    width: sprawl::style::Dimension::Points(200f32),
-                    height: sprawl::style::Dimension::Points(200f32),
+            taffy::style::Style {
+                flex_direction: taffy::style::FlexDirection::Column,
+                align_items: taffy::style::AlignItems::FlexStart,
+                size: taffy::geometry::Size {
+                    width: taffy::style::Dimension::Points(200f32),
+                    height: taffy::style::Dimension::Points(200f32),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -48,21 +48,21 @@ fn wrapped_row_within_align_items_flex_start() {
             &[node0],
         )
         .unwrap();
-    sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().size.height, 200f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.width, 200f32);
-    assert_eq!(sprawl.layout(node0).unwrap().size.height, 160f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node0).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.width, 150f32);
-    assert_eq!(sprawl.layout(node00).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node00).unwrap().location.y, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.width, 80f32);
-    assert_eq!(sprawl.layout(node01).unwrap().size.height, 80f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.x, 0f32);
-    assert_eq!(sprawl.layout(node01).unwrap().location.y, 80f32);
+    taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+    assert_eq!(taffy.layout(node).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().size.height, 200f32);
+    assert_eq!(taffy.layout(node).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.width, 200f32);
+    assert_eq!(taffy.layout(node0).unwrap().size.height, 160f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node0).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.width, 150f32);
+    assert_eq!(taffy.layout(node00).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node00).unwrap().location.y, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.width, 80f32);
+    assert_eq!(taffy.layout(node01).unwrap().size.height, 80f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.x, 0f32);
+    assert_eq!(taffy.layout(node01).unwrap().location.y, 80f32);
 }

--- a/tests/measure.rs
+++ b/tests/measure.rs
@@ -1,135 +1,129 @@
 #[cfg(test)]
 mod measure {
-    use sprawl::node::MeasureFunc;
-    use sprawl::number::OrElse;
+    use taffy::node::MeasureFunc;
+    use taffy::number::OrElse;
 
     #[test]
     fn measure_root() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let node = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let node = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(node).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(node).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child() {
-        let mut sprawl = sprawl::node::Sprawl::new();
+        let mut taffy = taffy::node::Taffy::new();
 
-        let child = sprawl
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[child]).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(node).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(node).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child_constraint() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        ..Default::default()
-                    },
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
                 },
                 &[child],
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(node).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(node).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(node).unwrap().size.height, 100.0);
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child_constraint_padding_parent() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        ..Default::default()
-                    },
-                    padding: sprawl::geometry::Rect {
-                        start: sprawl::style::Dimension::Points(10.0),
-                        end: sprawl::style::Dimension::Points(10.0),
-                        top: sprawl::style::Dimension::Points(10.0),
-                        bottom: sprawl::style::Dimension::Points(10.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50.0), ..Default::default() },
+                    padding: taffy::geometry::Rect {
+                        start: taffy::style::Dimension::Points(10.0),
+                        end: taffy::style::Dimension::Points(10.0),
+                        top: taffy::style::Dimension::Points(10.0),
+                        bottom: taffy::style::Dimension::Points(10.0),
                     },
                     ..Default::default()
                 },
                 &[child],
             )
             .unwrap();
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(node).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(node).unwrap().size.height, 120.0);
+        assert_eq!(taffy.layout(node).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(node).unwrap().size.height, 120.0);
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 30.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 30.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_child_with_flex_grow() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child0 = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child0 = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        height: sprawl::style::Dimension::Points(50.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(50.0),
+                        height: taffy::style::Dimension::Points(50.0),
                     },
                     ..Default::default()
                 },
@@ -137,44 +131,41 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = sprawl
+        let child1 = taffy
             .new_leaf(
-                sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { flex_grow: 1.0, ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(10.0),
                     height: constraint.height.or_else(50.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        ..Default::default()
-                    },
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100.0), ..Default::default() },
                     ..Default::default()
                 },
                 &[child0, child1],
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child1).unwrap().size.height, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn measure_child_with_flex_shrink() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child0 = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child0 = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        height: sprawl::style::Dimension::Points(50.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(50.0),
+                        height: taffy::style::Dimension::Points(50.0),
                     },
                     flex_shrink: 0.0,
                     ..Default::default()
@@ -183,44 +174,41 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = sprawl
+        let child1 = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(50.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        ..Default::default()
-                    },
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100.0), ..Default::default() },
                     ..Default::default()
                 },
                 &[child0, child1],
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child1).unwrap().size.height, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn remeasure_child_after_growing() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child0 = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child0 = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        height: sprawl::style::Dimension::Points(50.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(50.0),
+                        height: taffy::style::Dimension::Points(50.0),
                     },
                     ..Default::default()
                 },
@@ -228,47 +216,44 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = sprawl
+        let child1 = taffy
             .new_leaf(
-                sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
+                taffy::style::Style { flex_grow: 1.0, ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     let width = constraint.width.or_else(10.0);
                     let height = constraint.height.or_else(width * 2.0);
-                    sprawl::geometry::Size { width, height }
+                    taffy::geometry::Size { width, height }
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        ..Default::default()
-                    },
-                    align_items: sprawl::style::AlignItems::FlexStart,
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100.0), ..Default::default() },
+                    align_items: taffy::style::AlignItems::FlexStart,
                     ..Default::default()
                 },
                 &[child0, child1],
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn remeasure_child_after_shrinking() {
-        let mut sprawl = sprawl::node::Sprawl::new();
+        let mut taffy = taffy::node::Taffy::new();
 
-        let child0 = sprawl
+        let child0 = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        height: sprawl::style::Dimension::Points(50.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(50.0),
+                        height: taffy::style::Dimension::Points(50.0),
                     },
                     flex_shrink: 0.0,
                     ..Default::default()
@@ -277,58 +262,55 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = sprawl
+        let child1 = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
+                taffy::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     let width = constraint.width.or_else(100.0);
                     let height = constraint.height.or_else(width * 2.0);
-                    sprawl::geometry::Size { width, height }
+                    taffy::geometry::Size { width, height }
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        ..Default::default()
-                    },
-                    align_items: sprawl::style::AlignItems::FlexStart,
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(100.0), ..Default::default() },
+                    align_items: taffy::style::AlignItems::FlexStart,
                     ..Default::default()
                 },
                 &[child0, child1],
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child1).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn remeasure_child_after_stretching() {
-        let mut sprawl = sprawl::node::Sprawl::new();
+        let mut taffy = taffy::node::Taffy::new();
 
-        let child = sprawl
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
+                taffy::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     let height = constraint.height.or_else(50.0);
                     let width = constraint.width.or_else(height);
-                    sprawl::geometry::Size { width, height }
+                    taffy::geometry::Size { width, height }
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        height: sprawl::style::Dimension::Points(100.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(100.0),
+                        height: taffy::style::Dimension::Points(100.0),
                     },
                     ..Default::default()
                 },
@@ -336,71 +318,65 @@ mod measure {
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn width_overrides_measure() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(50.0),
-                        ..Default::default()
-                    },
+                taffy::style::Style {
+                    size: taffy::geometry::Size { width: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[child]).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn height_overrides_measure() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        height: sprawl::style::Dimension::Points(50.0),
-                        ..Default::default()
-                    },
+                taffy::style::Style {
+                    size: taffy::geometry::Size { height: taffy::style::Dimension::Points(50.0), ..Default::default() },
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[child]).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 50.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn flex_basis_overrides_measure() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child0 = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child0 = taffy
             .new_node(
-                sprawl::style::Style {
-                    flex_basis: sprawl::style::Dimension::Points(50.0),
+                taffy::style::Style {
+                    flex_basis: taffy::style::Dimension::Points(50.0),
                     flex_grow: 1.0,
                     ..Default::default()
                 },
@@ -408,26 +384,26 @@ mod measure {
             )
             .unwrap();
 
-        let child1 = sprawl
+        let child1 = taffy
             .new_leaf(
-                sprawl::style::Style {
-                    flex_basis: sprawl::style::Dimension::Points(50.0),
+                taffy::style::Style {
+                    flex_basis: taffy::style::Dimension::Points(50.0),
                     flex_grow: 1.0,
                     ..Default::default()
                 },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(100.0),
                     height: constraint.height.or_else(100.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(200.0),
-                        height: sprawl::style::Dimension::Points(100.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(200.0),
+                        height: taffy::style::Dimension::Points(100.0),
                     },
                     ..Default::default()
                 },
@@ -435,33 +411,33 @@ mod measure {
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child0).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(child0).unwrap().size.height, 100.0);
-        assert_eq!(sprawl.layout(child1).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(child1).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child0).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child0).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child1).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn stretch_overrides_measure() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(50.0),
                     height: constraint.height.or_else(50.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        height: sprawl::style::Dimension::Points(100.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(100.0),
+                        height: taffy::style::Dimension::Points(100.0),
                     },
                     ..Default::default()
                 },
@@ -469,31 +445,31 @@ mod measure {
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn measure_absolute_child() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { position_type: sprawl::style::PositionType::Absolute, ..Default::default() },
-                MeasureFunc::Raw(|constraint| sprawl::geometry::Size {
+                taffy::style::Style { position_type: taffy::style::PositionType::Absolute, ..Default::default() },
+                MeasureFunc::Raw(|constraint| taffy::geometry::Size {
                     width: constraint.width.or_else(50.0),
                     height: constraint.height.or_else(50.0),
                 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        height: sprawl::style::Dimension::Points(100.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(100.0),
+                        height: taffy::style::Dimension::Points(100.0),
                     },
                     ..Default::default()
                 },
@@ -501,28 +477,28 @@ mod measure {
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 50.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 50.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 50.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 50.0);
     }
 
     #[test]
     fn ignore_invalid_measure() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let child = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let child = taffy
             .new_leaf(
-                sprawl::style::Style { flex_grow: 1.0, ..Default::default() },
-                MeasureFunc::Raw(|_| sprawl::geometry::Size { width: 200.0, height: 200.0 }),
+                taffy::style::Style { flex_grow: 1.0, ..Default::default() },
+                MeasureFunc::Raw(|_| taffy::geometry::Size { width: 200.0, height: 200.0 }),
             )
             .unwrap();
 
-        let node = sprawl
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(100.0),
-                        height: sprawl::style::Dimension::Points(100.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(100.0),
+                        height: taffy::style::Dimension::Points(100.0),
                     },
                     ..Default::default()
                 },
@@ -530,25 +506,25 @@ mod measure {
             )
             .unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.layout(child).unwrap().size.width, 100.0);
-        assert_eq!(sprawl.layout(child).unwrap().size.height, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.width, 100.0);
+        assert_eq!(taffy.layout(child).unwrap().size.height, 100.0);
     }
 
     #[test]
     fn only_measure_once() {
         use std::sync::atomic;
 
-        let mut sprawl = sprawl::node::Sprawl::new();
+        let mut taffy = taffy::node::Taffy::new();
         static NUM_MEASURES: atomic::AtomicU32 = atomic::AtomicU32::new(0);
 
-        let grandchild = sprawl
+        let grandchild = taffy
             .new_leaf(
-                sprawl::style::Style { ..Default::default() },
+                taffy::style::Style { ..Default::default() },
                 MeasureFunc::Raw(|constraint| {
                     NUM_MEASURES.fetch_add(1, atomic::Ordering::Relaxed);
-                    sprawl::geometry::Size {
+                    taffy::geometry::Size {
                         width: constraint.width.or_else(50.0),
                         height: constraint.height.or_else(50.0),
                     }
@@ -556,10 +532,10 @@ mod measure {
             )
             .unwrap();
 
-        let child = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[grandchild]).unwrap();
+        let child = taffy.new_node(taffy::style::Style { ..Default::default() }, &[grandchild]).unwrap();
 
-        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[child]).unwrap();
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[child]).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
         assert_eq!(NUM_MEASURES.load(atomic::Ordering::Relaxed), 2);
     }

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,191 +1,191 @@
 #[cfg(test)]
 mod node {
-    use sprawl::geometry::*;
-    use sprawl::node::{MeasureFunc, Sprawl};
-    use sprawl::style::*;
+    use taffy::geometry::*;
+    use taffy::node::{MeasureFunc, Taffy};
+    use taffy::style::*;
 
     #[test]
     fn children() {
-        let mut sprawl = Sprawl::new();
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
+        let mut taffy = Taffy::new();
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
+        let node = taffy.new_node(Style::default(), &[child1, child2]).unwrap();
 
-        assert_eq!(sprawl.child_count(node).unwrap(), 2);
-        assert_eq!(sprawl.children(node).unwrap()[0], child1);
-        assert_eq!(sprawl.children(node).unwrap()[1], child2);
+        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.children(node).unwrap()[0], child1);
+        assert_eq!(taffy.children(node).unwrap()[1], child2);
     }
 
     #[test]
     fn set_measure() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
         let node =
-            sprawl.new_leaf(Style::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 })).unwrap();
-        sprawl.compute_layout(node, Size::undefined()).unwrap();
-        assert_eq!(sprawl.layout(node).unwrap().size.width, 200.0);
+            taffy.new_leaf(Style::default(), MeasureFunc::Raw(|_| Size { width: 200.0, height: 200.0 })).unwrap();
+        taffy.compute_layout(node, Size::undefined()).unwrap();
+        assert_eq!(taffy.layout(node).unwrap().size.width, 200.0);
 
-        sprawl.set_measure(node, Some(MeasureFunc::Raw(|_| Size { width: 100.0, height: 100.0 }))).unwrap();
-        sprawl.compute_layout(node, Size::undefined()).unwrap();
-        assert_eq!(sprawl.layout(node).unwrap().size.width, 100.0);
+        taffy.set_measure(node, Some(MeasureFunc::Raw(|_| Size { width: 100.0, height: 100.0 }))).unwrap();
+        taffy.compute_layout(node, Size::undefined()).unwrap();
+        assert_eq!(taffy.layout(node).unwrap().size.width, 100.0);
     }
 
     #[test]
     fn add_child() {
-        let mut sprawl = Sprawl::new();
-        let node = sprawl.new_node(Style::default(), &[]).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 0);
+        let mut taffy = Taffy::new();
+        let node = taffy.new_node(Style::default(), &[]).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 0);
 
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        sprawl.add_child(node, child1).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 1);
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        taffy.add_child(node, child1).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 1);
 
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
-        sprawl.add_child(node, child2).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 2);
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
+        taffy.add_child(node, child2).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 2);
     }
 
     #[test]
     fn remove_child() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
 
-        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 2);
+        let node = taffy.new_node(Style::default(), &[child1, child2]).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 2);
 
-        sprawl.remove_child(node, child1).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 1);
-        assert_eq!(sprawl.children(node).unwrap()[0], child2);
+        taffy.remove_child(node, child1).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.children(node).unwrap()[0], child2);
 
-        sprawl.remove_child(node, child2).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 0);
+        taffy.remove_child(node, child2).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 0);
     }
 
     #[test]
     fn remove_child_at_index() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
 
-        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 2);
+        let node = taffy.new_node(Style::default(), &[child1, child2]).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 2);
 
-        sprawl.remove_child_at_index(node, 0).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 1);
-        assert_eq!(sprawl.children(node).unwrap()[0], child2);
+        taffy.remove_child_at_index(node, 0).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.children(node).unwrap()[0], child2);
 
-        sprawl.remove_child_at_index(node, 0).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 0);
+        taffy.remove_child_at_index(node, 0).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 0);
     }
 
     #[test]
     fn replace_child_at_index() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
 
-        let node = sprawl.new_node(Style::default(), &[child1]).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 1);
-        assert_eq!(sprawl.children(node).unwrap()[0], child1);
+        let node = taffy.new_node(Style::default(), &[child1]).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.children(node).unwrap()[0], child1);
 
-        sprawl.replace_child_at_index(node, 0, child2).unwrap();
-        assert_eq!(sprawl.child_count(node).unwrap(), 1);
-        assert_eq!(sprawl.children(node).unwrap()[0], child2);
+        taffy.replace_child_at_index(node, 0, child2).unwrap();
+        assert_eq!(taffy.child_count(node).unwrap(), 1);
+        assert_eq!(taffy.children(node).unwrap()[0], child2);
     }
 
     #[test]
     fn remove() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
         let style2 = Style { flex_direction: FlexDirection::Column, ..Style::default() };
 
         // Build a linear tree layout: <0> <- <1> <- <2>
-        let node2 = sprawl.new_node(style2, &[]).unwrap();
-        let node1 = sprawl.new_node(Style::default(), &[node2]).unwrap();
-        let node0 = sprawl.new_node(Style::default(), &[node1]).unwrap();
+        let node2 = taffy.new_node(style2, &[]).unwrap();
+        let node1 = taffy.new_node(Style::default(), &[node2]).unwrap();
+        let node0 = taffy.new_node(Style::default(), &[node1]).unwrap();
 
-        assert_eq!(sprawl.children(node0).unwrap().as_slice(), &[node1]);
+        assert_eq!(taffy.children(node0).unwrap().as_slice(), &[node1]);
 
         // Disconnect the tree: <0> <2>
-        sprawl.remove(node1);
+        taffy.remove(node1);
 
-        assert!(sprawl.style(node1).is_err());
+        assert!(taffy.style(node1).is_err());
 
-        assert!(sprawl.children(node0).unwrap().is_empty());
-        assert!(sprawl.children(node2).unwrap().is_empty());
-        assert_eq!(sprawl.style(node2).unwrap().flex_direction, style2.flex_direction);
+        assert!(taffy.children(node0).unwrap().is_empty());
+        assert!(taffy.children(node2).unwrap().is_empty());
+        assert_eq!(taffy.style(node2).unwrap().flex_direction, style2.flex_direction);
     }
 
     #[test]
     fn set_children() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
+        let node = taffy.new_node(Style::default(), &[child1, child2]).unwrap();
 
-        assert_eq!(sprawl.child_count(node).unwrap(), 2);
-        assert_eq!(sprawl.children(node).unwrap()[0], child1);
-        assert_eq!(sprawl.children(node).unwrap()[1], child2);
+        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.children(node).unwrap()[0], child1);
+        assert_eq!(taffy.children(node).unwrap()[1], child2);
 
-        let child3 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child4 = sprawl.new_node(Style::default(), &[]).unwrap();
-        sprawl.set_children(node, &[child3, child4]).unwrap();
+        let child3 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child4 = taffy.new_node(Style::default(), &[]).unwrap();
+        taffy.set_children(node, &[child3, child4]).unwrap();
 
-        assert_eq!(sprawl.child_count(node).unwrap(), 2);
-        assert_eq!(sprawl.children(node).unwrap()[0], child3);
-        assert_eq!(sprawl.children(node).unwrap()[1], child4);
+        assert_eq!(taffy.child_count(node).unwrap(), 2);
+        assert_eq!(taffy.children(node).unwrap()[0], child3);
+        assert_eq!(taffy.children(node).unwrap()[1], child4);
     }
 
     #[test]
     fn set_style() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let node = sprawl.new_node(Style::default(), &[]).unwrap();
-        assert_eq!(sprawl.style(node).unwrap().display, Display::Flex);
+        let node = taffy.new_node(Style::default(), &[]).unwrap();
+        assert_eq!(taffy.style(node).unwrap().display, Display::Flex);
 
-        sprawl.set_style(node, Style { display: Display::None, ..Style::default() }).unwrap();
-        assert_eq!(sprawl.style(node).unwrap().display, Display::None);
+        taffy.set_style(node, Style { display: Display::None, ..Style::default() }).unwrap();
+        assert_eq!(taffy.style(node).unwrap().display, Display::None);
     }
 
     #[test]
     fn mark_dirty() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let child1 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child2 = sprawl.new_node(Style::default(), &[]).unwrap();
-        let node = sprawl.new_node(Style::default(), &[child1, child2]).unwrap();
+        let child1 = taffy.new_node(Style::default(), &[]).unwrap();
+        let child2 = taffy.new_node(Style::default(), &[]).unwrap();
+        let node = taffy.new_node(Style::default(), &[child1, child2]).unwrap();
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
 
-        assert_eq!(sprawl.dirty(child1).unwrap(), false);
-        assert_eq!(sprawl.dirty(child2).unwrap(), false);
-        assert_eq!(sprawl.dirty(node).unwrap(), false);
+        assert_eq!(taffy.dirty(child1).unwrap(), false);
+        assert_eq!(taffy.dirty(child2).unwrap(), false);
+        assert_eq!(taffy.dirty(node).unwrap(), false);
 
-        sprawl.mark_dirty(node).unwrap();
-        assert_eq!(sprawl.dirty(child1).unwrap(), false);
-        assert_eq!(sprawl.dirty(child2).unwrap(), false);
-        assert_eq!(sprawl.dirty(node).unwrap(), true);
+        taffy.mark_dirty(node).unwrap();
+        assert_eq!(taffy.dirty(child1).unwrap(), false);
+        assert_eq!(taffy.dirty(child2).unwrap(), false);
+        assert_eq!(taffy.dirty(node).unwrap(), true);
 
-        sprawl.compute_layout(node, sprawl::geometry::Size::undefined()).unwrap();
-        sprawl.mark_dirty(child1).unwrap();
-        assert_eq!(sprawl.dirty(child1).unwrap(), true);
-        assert_eq!(sprawl.dirty(child2).unwrap(), false);
-        assert_eq!(sprawl.dirty(node).unwrap(), true);
+        taffy.compute_layout(node, taffy::geometry::Size::undefined()).unwrap();
+        taffy.mark_dirty(child1).unwrap();
+        assert_eq!(taffy.dirty(child1).unwrap(), true);
+        assert_eq!(taffy.dirty(child2).unwrap(), false);
+        assert_eq!(taffy.dirty(node).unwrap(), true);
     }
 
     #[test]
     fn remove_last_node() {
-        let mut sprawl = Sprawl::new();
+        let mut taffy = Taffy::new();
 
-        let parent = sprawl.new_node(Style::default(), &[]).unwrap();
-        let child = sprawl.new_node(Style::default(), &[]).unwrap();
-        sprawl.add_child(parent, child).unwrap();
+        let parent = taffy.new_node(Style::default(), &[]).unwrap();
+        let child = taffy.new_node(Style::default(), &[]).unwrap();
+        taffy.add_child(parent, child).unwrap();
 
-        sprawl.remove(child);
-        sprawl.remove(parent);
+        taffy.remove(child);
+        taffy.remove(parent);
     }
 }

--- a/tests/relayout.rs
+++ b/tests/relayout.rs
@@ -1,63 +1,63 @@
-use sprawl::style::Dimension;
+use taffy::style::Dimension;
 
 #[test]
 fn relayout() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node1 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: Dimension::Points(8f32), height: Dimension::Points(80f32) },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::prelude::AlignSelf::Center,
-                size: sprawl::geometry::Size { width: Dimension::Auto, height: Dimension::Auto },
-                // size: sprawl::geometry::Size { width: Dimension::Percent(1.0), height: Dimension::Percent(1.0) },
+            taffy::style::Style {
+                align_self: taffy::prelude::AlignSelf::Center,
+                size: taffy::geometry::Size { width: Dimension::Auto, height: Dimension::Auto },
+                // size: taffy::geometry::Size { width: Dimension::Percent(1.0), height: Dimension::Percent(1.0) },
                 ..Default::default()
             },
             &[node1],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: Dimension::Percent(1f32), height: Dimension::Percent(1f32) },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: Dimension::Percent(1f32), height: Dimension::Percent(1f32) },
                 ..Default::default()
             },
             &[node0],
         )
         .unwrap();
     println!("0:");
-    sprawl
+    taffy
         .compute_layout(
             node,
-            sprawl::geometry::Size {
-                width: sprawl::prelude::Number::Defined(100f32),
-                height: sprawl::prelude::Number::Defined(100f32),
+            taffy::geometry::Size {
+                width: taffy::prelude::Number::Defined(100f32),
+                height: taffy::prelude::Number::Defined(100f32),
             },
         )
         .unwrap();
-    let initial = sprawl.layout(node).unwrap().location;
-    let initial0 = sprawl.layout(node0).unwrap().location;
-    let initial1 = sprawl.layout(node1).unwrap().location;
+    let initial = taffy.layout(node).unwrap().location;
+    let initial0 = taffy.layout(node0).unwrap().location;
+    let initial1 = taffy.layout(node1).unwrap().location;
     for i in 1..10 {
         println!("\n\n{i}:");
-        sprawl
+        taffy
             .compute_layout(
                 node,
-                sprawl::geometry::Size {
-                    width: sprawl::prelude::Number::Defined(100f32),
-                    height: sprawl::prelude::Number::Defined(100f32),
+                taffy::geometry::Size {
+                    width: taffy::prelude::Number::Defined(100f32),
+                    height: taffy::prelude::Number::Defined(100f32),
                 },
             )
             .unwrap();
-        assert_eq!(sprawl.layout(node).unwrap().location, initial);
-        assert_eq!(sprawl.layout(node0).unwrap().location, initial0);
-        assert_eq!(sprawl.layout(node1).unwrap().location, initial1);
+        assert_eq!(taffy.layout(node).unwrap().location, initial);
+        assert_eq!(taffy.layout(node0).unwrap().location, initial0);
+        assert_eq!(taffy.layout(node1).unwrap().location, initial1);
     }
 }

--- a/tests/root_constraints.rs
+++ b/tests/root_constraints.rs
@@ -1,16 +1,16 @@
 #[cfg(test)]
 mod root_constraints {
-    use sprawl::number::*;
+    use taffy::number::*;
 
     #[test]
     fn root_with_percentage_size() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let node = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Percent(1.0),
-                        height: sprawl::style::Dimension::Percent(1.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Percent(1.0),
+                        height: taffy::style::Dimension::Percent(1.0),
                     },
                     ..Default::default()
                 },
@@ -18,13 +18,13 @@ mod root_constraints {
             )
             .unwrap();
 
-        sprawl
+        taffy
             .compute_layout(
                 node,
-                sprawl::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(200.0) },
+                taffy::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(200.0) },
             )
             .unwrap();
-        let layout = sprawl.layout(node).unwrap();
+        let layout = taffy.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 100.0);
         assert_eq!(layout.size.height, 200.0);
@@ -32,16 +32,16 @@ mod root_constraints {
 
     #[test]
     fn root_with_no_size() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let node = sprawl.new_node(sprawl::style::Style { ..Default::default() }, &[]).unwrap();
+        let mut taffy = taffy::node::Taffy::new();
+        let node = taffy.new_node(taffy::style::Style { ..Default::default() }, &[]).unwrap();
 
-        sprawl
+        taffy
             .compute_layout(
                 node,
-                sprawl::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(100.0) },
+                taffy::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(100.0) },
             )
             .unwrap();
-        let layout = sprawl.layout(node).unwrap();
+        let layout = taffy.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 0.0);
         assert_eq!(layout.size.height, 0.0);
@@ -49,13 +49,13 @@ mod root_constraints {
 
     #[test]
     fn root_with_larger_size() {
-        let mut sprawl = sprawl::node::Sprawl::new();
-        let node = sprawl
+        let mut taffy = taffy::node::Taffy::new();
+        let node = taffy
             .new_node(
-                sprawl::style::Style {
-                    size: sprawl::geometry::Size {
-                        width: sprawl::style::Dimension::Points(200.0),
-                        height: sprawl::style::Dimension::Points(200.0),
+                taffy::style::Style {
+                    size: taffy::geometry::Size {
+                        width: taffy::style::Dimension::Points(200.0),
+                        height: taffy::style::Dimension::Points(200.0),
                     },
                     ..Default::default()
                 },
@@ -63,13 +63,13 @@ mod root_constraints {
             )
             .unwrap();
 
-        sprawl
+        taffy
             .compute_layout(
                 node,
-                sprawl::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(100.0) },
+                taffy::geometry::Size { width: Number::Defined(100.0), height: Number::Defined(100.0) },
             )
             .unwrap();
-        let layout = sprawl.layout(node).unwrap();
+        let layout = taffy.layout(node).unwrap();
 
         assert_eq!(layout.size.width, 200.0);
         assert_eq!(layout.size.height, 200.0);

--- a/tests/simple_child.rs
+++ b/tests/simple_child.rs
@@ -1,79 +1,79 @@
-use sprawl::{geometry::Point, style::Dimension};
+use taffy::{geometry::Point, style::Dimension};
 
 #[test]
 fn simple_child() {
-    let mut sprawl = sprawl::Sprawl::new();
-    let node0_0 = sprawl
+    let mut taffy = taffy::Taffy::new();
+    let node0_0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::prelude::AlignSelf::Center,
-                size: sprawl::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            taffy::style::Style {
+                align_self: taffy::prelude::AlignSelf::Center,
+                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node0 = sprawl
+    let node0 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
                 ..Default::default()
             },
             &[node0_0],
         )
         .unwrap();
-    let node1_0 = sprawl
+    let node1_0 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::prelude::AlignSelf::Center,
-                size: sprawl::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            taffy::style::Style {
+                align_self: taffy::prelude::AlignSelf::Center,
+                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1_1 = sprawl
+    let node1_1 = taffy
         .new_node(
-            sprawl::style::Style {
-                align_self: sprawl::prelude::AlignSelf::Center,
-                size: sprawl::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
+            taffy::style::Style {
+                align_self: taffy::prelude::AlignSelf::Center,
+                size: taffy::geometry::Size { width: Dimension::Points(10f32), height: Dimension::Points(10f32) },
                 ..Default::default()
             },
             &[],
         )
         .unwrap();
-    let node1 = sprawl
+    let node1 = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: Dimension::Undefined, height: Dimension::Undefined },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: Dimension::Undefined, height: Dimension::Undefined },
                 ..Default::default()
             },
             &[node1_0, node1_1],
         )
         .unwrap();
-    let node = sprawl
+    let node = taffy
         .new_node(
-            sprawl::style::Style {
-                size: sprawl::geometry::Size { width: Dimension::Percent(100.0), height: Dimension::Percent(100.0) },
+            taffy::style::Style {
+                size: taffy::geometry::Size { width: Dimension::Percent(100.0), height: Dimension::Percent(100.0) },
                 ..Default::default()
             },
             &[node0, node1],
         )
         .unwrap();
-    sprawl
+    taffy
         .compute_layout(
             node,
-            sprawl::geometry::Size {
-                width: sprawl::prelude::Number::Defined(100f32),
-                height: sprawl::prelude::Number::Defined(100f32),
+            taffy::geometry::Size {
+                width: taffy::prelude::Number::Defined(100f32),
+                height: taffy::prelude::Number::Defined(100f32),
             },
         )
         .unwrap();
-    assert_eq!(sprawl.layout(node).unwrap().location, Point { x: 0.0, y: 0.0 });
-    assert_eq!(sprawl.layout(node0).unwrap().location, Point { x: 0.0, y: 0.0 });
-    assert_eq!(sprawl.layout(node1).unwrap().location, Point { x: 10.0, y: 0.0 });
-    assert_eq!(sprawl.layout(node0_0).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(node).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(node0).unwrap().location, Point { x: 0.0, y: 0.0 });
+    assert_eq!(taffy.layout(node1).unwrap().location, Point { x: 10.0, y: 0.0 });
+    assert_eq!(taffy.layout(node0_0).unwrap().location, Point { x: 0.0, y: 0.0 });
     // Layout is relative so node1_0 location starts at (0,0) and is not ofset by it's parent location
-    assert_eq!(sprawl.layout(node1_0).unwrap().location, Point { x: 00.0, y: 0.0 });
-    assert_eq!(sprawl.layout(node1_1).unwrap().location, Point { x: 10.0, y: 0.0 });
+    assert_eq!(taffy.layout(node1_0).unwrap().location, Point { x: 00.0, y: 0.0 });
+    assert_eq!(taffy.layout(node1_1).unwrap().location, Point { x: 10.0, y: 0.0 });
 }


### PR DESCRIPTION
# Objective

Fixes #11 and fixes #60. As the issue states, the sprawl name was taken by a genuine crate author since the voting closed. This is a nice memorable backup name, with good branding opportunities.

I'll be publishing to crates.io as soon as this is merged.